### PR TITLE
Disallow eslint warnings from being merged

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ install:
 script:
 - make validate-no-uncommitted-package-lock-changes
 - npm run i18n_extract
-- npm run lint
+- npm run lint -- --max-warnings 0
 - npm run test
 - npm run build
 - npm run is-es5


### PR DESCRIPTION
eslint errors were already prohibited; this just makes it stricter.

We were already at 0 eslint warnings anyway; this would just keep us there.

Any objections @arbrandes ?