### PR TITLE
[BD-14] List filtering and library details

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -14,7 +14,8 @@ import { NotFoundPage } from './generic';
 import {
   ROUTES,
   LibraryBlockPage,
-  LibraryDetailPage,
+  LibraryEditPage,
+  LibraryPage,
   LibraryListPage,
   StudioHeader,
 } from './library-authoring';
@@ -34,7 +35,8 @@ subscribe(APP_READY, () => {
         <main>
           <Switch>
             <Route exact path={ROUTES.List.HOME} component={LibraryListPage} />
-            <Route exact path={ROUTES.Detail.HOME} component={LibraryDetailPage} />
+            <Route exact path={ROUTES.Detail.HOME} component={LibraryPage} />
+            <Route exact path={ROUTES.Detail.EDIT} component={LibraryEditPage} />
             <Route exact path={ROUTES.Block.HOME} component={LibraryBlockPage} />
             <Route exact path={ROUTES.Block.EDIT} component={LibraryBlockPage} />
             <Route exact path={ROUTES.Block.ASSETS} component={LibraryBlockPage} />

--- a/src/library-authoring/common/data/constants.js
+++ b/src/library-authoring/common/data/constants.js
@@ -23,6 +23,8 @@ export const ROUTES = {
   Detail: {
     HOME: '/library/:libraryId',
     HOME_SLUG: (libraryId) => `/library/${libraryId}`,
+    EDIT: '/library/:libraryId/edit',
+    EDIT_SLUG: (libraryId) => `/library/${libraryId}/edit`,
   },
   Block: {
     HOME: '/library/:libraryId/blocks/:blockId',

--- a/src/library-authoring/common/data/utils.js
+++ b/src/library-authoring/common/data/utils.js
@@ -44,7 +44,7 @@ export const filterSupportedBlockTypes = (library) => {
   };
 };
 
-/* Given a v1 library key, unpack it into org and slug. */
+/** Given a v1 library key, unpack it into org and slug. */
 export const unpackLibraryKey = (key) => {
   const re = /library-v1:(?<org>.+)\+(?<slug>.+)/;
   const match = key.match(re);
@@ -56,3 +56,8 @@ export const unpackLibraryKey = (key) => {
     slug: null,
   };
 };
+
+/** Truncate an error message to 255 characters if it's longer than that. */
+export const truncateErrorMessage = (errorMessage) => (
+  errorMessage.length > 255 ? `${errorMessage.substring(0, 255)}...` : errorMessage
+);

--- a/src/library-authoring/create-library/LibraryCreateForm.jsx
+++ b/src/library-authoring/create-library/LibraryCreateForm.jsx
@@ -7,8 +7,14 @@ import {
 } from '@edx/paragon';
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 
-import { LIBRARY_TYPES, SUBMISSION_STATUS, libraryShape } from '../common';
 import {
+  LIBRARY_TYPES,
+  SUBMISSION_STATUS,
+  libraryShape,
+  truncateErrorMessage,
+} from '../common';
+import {
+  clearFormError,
   createLibrary,
   libraryCreateInitialState,
   resetForm,
@@ -115,6 +121,10 @@ class LibraryCreateForm extends React.Component {
     return state;
   }
 
+  handleDismissAlert = () => {
+    this.props.clearFormError();
+  }
+
   render() {
     const { intl, errorMessage } = this.props;
     const { data } = this.state;
@@ -127,10 +137,11 @@ class LibraryCreateForm extends React.Component {
           && (
           <Alert
             variant="danger"
-            dialog={errorMessage}
-            onClose={() => {}}
-            open
-          />
+            onClose={this.handleDismissAlert}
+            dismissible
+          >
+            {truncateErrorMessage(errorMessage)}
+          </Alert>
           )}
           <ol className="list-input">
             <li className="field">
@@ -250,6 +261,7 @@ class LibraryCreateForm extends React.Component {
 }
 
 LibraryCreateForm.propTypes = {
+  clearFormError: PropTypes.func.isRequired,
   createdLibrary: libraryShape,
   createLibrary: PropTypes.func.isRequired,
   errorFields: PropTypes.object, // eslint-disable-line react/forbid-prop-types
@@ -268,7 +280,8 @@ LibraryCreateForm.defaultProps = libraryCreateInitialState;
 export default connect(
   selectLibraryCreate,
   {
-    resetForm,
+    clearFormError,
     createLibrary,
+    resetForm,
   },
 )(injectIntl(withRouter(LibraryCreateForm)));

--- a/src/library-authoring/create-library/data/slice.js
+++ b/src/library-authoring/create-library/data/slice.js
@@ -29,6 +29,9 @@ const slice = createSlice({
       state.errorFields = payload.errorFields;
       state.status = SUBMISSION_STATUS.FAILED;
     },
+    libraryCreateClearError: (state) => {
+      state.errorMessage = null;
+    },
     libraryCreateReset: (state) => {
       state.createdLibrary = libraryCreateInitialState.createdLibrary;
       state.errorMessage = libraryCreateInitialState.errorMessage;

--- a/src/library-authoring/create-library/data/thunks.js
+++ b/src/library-authoring/create-library/data/thunks.js
@@ -16,3 +16,7 @@ export const createLibrary = ({ data }) => async (dispatch) => {
 export const resetForm = () => async (dispatch) => {
   dispatch(actions.libraryCreateReset());
 };
+
+export const clearFormError = () => async (dispatch) => {
+  dispatch(actions.libraryCreateClearError());
+};

--- a/src/library-authoring/edit-block/LibraryBlockAssets.jsx
+++ b/src/library-authoring/edit-block/LibraryBlockAssets.jsx
@@ -20,7 +20,7 @@ const LibraryBlockAssets = (props) => {
             <li key={assetFile.path}>
               <a href={assetFile.url}>/static/{assetFile.path}</a> {' '}
               ({Math.round(assetFile.size / 1024.0)} KB)
-              (<Button onClick={() => props.onDeleteFile(assetFile.path)} className="btn btn-link p-0" title="Delete this file">x</Button>)
+              (<Button variant="link" onClick={() => props.onDeleteFile(assetFile.path)} className="p-0" title="Delete this file">x</Button>)
             </li>
           ))
         }

--- a/src/library-authoring/edit-block/LibraryBlockOlx.jsx
+++ b/src/library-authoring/edit-block/LibraryBlockOlx.jsx
@@ -52,8 +52,8 @@ class LibraryBlockOlx extends React.Component {
             }}
           />
           <br />
-          <Button onClick={this.cancelEditMode} className="btn btn-outline-secondary">Cancel</Button>
-          <Button onClick={this.saveOlx} className="btn btn-primary">Save Changes</Button>
+          <Button variant="outline-secondary" onClick={this.cancelEditMode}>Cancel</Button>
+          <Button variant="primary" onClick={this.saveOlx}>Save Changes</Button>
         </>
       );
     }

--- a/src/library-authoring/edit-block/data/slice.js
+++ b/src/library-authoring/edit-block/data/slice.js
@@ -58,6 +58,9 @@ const slice = createSlice({
       state.errorMessage = payload.errorMessage;
       state.status = LOADING_STATUS.FAILED;
     },
+    libraryBlockClearError: (state) => {
+      state.errorMessage = null;
+    },
   },
 });
 

--- a/src/library-authoring/edit-block/data/thunks.js
+++ b/src/library-authoring/edit-block/data/thunks.js
@@ -44,6 +44,10 @@ export const uploadLibraryBlockAssets = ({ blockId, files }) => async (dispatch)
      * A parallelized implementation would be faster but currently
      * doesn't work due to a race condition in blockstore. */
     files.forEach(file => api.addLibraryBlockAsset(blockId, file.name, file));
+
+    /* This is hackish, but we have to wait for Studio/blockstore to process the files before refreshing them. */
+    await new Promise(r => setTimeout(r, 1000));
+
     dispatch(actions.libraryBlockAssetsSuccess({
       assets: await api.getLibraryBlockAssets(blockId),
       metadata: await api.getLibraryBlock(blockId),
@@ -102,4 +106,12 @@ export const deleteLibraryBlock = ({ blockId }) => async (dispatch) => {
     dispatch(actions.libraryBlockFailed({ errorMessage: error.message }));
     logError(error);
   }
+};
+
+export const setLibraryBlockError = ({ errorMessage }) => async (dispatch) => {
+  dispatch(actions.libraryBlockFailed({ errorMessage }));
+};
+
+export const clearLibraryBlockError = () => async (dispatch) => {
+  dispatch(actions.libraryBlockClearError());
 };

--- a/src/library-authoring/edit-library/LibraryEditPage.jsx
+++ b/src/library-authoring/edit-library/LibraryEditPage.jsx
@@ -1,0 +1,351 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  Alert,
+  Button,
+  Form,
+  Icon,
+  Input,
+  StatefulButton,
+  ValidationFormGroup,
+} from '@edx/paragon';
+import { connect } from 'react-redux';
+import { withRouter } from 'react-router';
+import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { AppContext } from '@edx/frontend-platform/react';
+
+import { LoadingPage } from '../../generic';
+import {
+  LOADING_STATUS,
+  SUBMISSION_STATUS,
+  libraryShape,
+  truncateErrorMessage,
+} from '../common';
+import {
+  fetchLibraryDetail,
+} from '../library-detail';
+import {
+  clearError,
+  libraryEditInitialState,
+  selectLibraryEdit,
+  updateLibrary,
+} from './data';
+import messages from './messages';
+
+class LibraryEditPage extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      data: {
+        id: null,
+        title: '',
+        description: '',
+        allow_public_learning: false,
+        allow_public_read: false,
+      },
+    };
+  }
+
+  componentDidMount() {
+    if (this.props.library === null) {
+      const { libraryId } = this.props.match.params;
+      this.props.fetchLibraryDetail({ libraryId });
+    } else {
+      this.syncLibraryData();
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    if (this.props.library !== prevProps.library) {
+      this.syncLibraryData();
+    }
+
+    if (
+      this.props.submissionStatus !== prevProps.submissionStatus
+      && this.props.submissionStatus === SUBMISSION_STATUS.SUBMITTED
+    ) {
+      this.props.history.push(this.props.library.url);
+    }
+  }
+
+  syncLibraryData = () => {
+    const { library } = this.props;
+    this.setState({
+      data: {
+        libraryId: library.id,
+        title: library.title,
+        description: library.description,
+        allow_public_learning: library.allow_public_learning,
+        allow_public_read: library.allow_public_read,
+      },
+    });
+  }
+
+  hasFieldError = (fieldName) => {
+    const { errorFields } = this.props;
+
+    if (errorFields && (fieldName in errorFields)) {
+      return true;
+    }
+
+    return false;
+  }
+
+  getFieldError = (fieldName) => {
+    if (this.hasFieldError(fieldName)) {
+      return this.props.errorFields[fieldName];
+    }
+
+    return null;
+  }
+
+  formIsValid = () => {
+    const { data } = this.state;
+
+    if (data.libraryId && data.title && data.description) {
+      return true;
+    }
+
+    return false;
+  }
+
+  getSubmitButtonState = () => {
+    const { submissionStatus } = this.props;
+
+    let state;
+    if (submissionStatus === SUBMISSION_STATUS.SUBMITTING) {
+      state = 'pending';
+    } else if (this.formIsValid()) {
+      state = 'enabled';
+    } else {
+      state = 'disabled';
+    }
+
+    return state;
+  }
+
+  handleDismissAlert = () => {
+    this.props.clearError();
+  }
+
+  handleValueChange = (event) => {
+    const el = event.target;
+    this.setState(state => ({
+      data: {
+        ...state.data,
+        [el.name]: el.type === 'checkbox' ? el.checked : el.value,
+      },
+    }));
+  }
+
+  handleSubmit = (event) => {
+    event.preventDefault();
+    this.props.updateLibrary({ data: this.state.data });
+  }
+
+  handleCancel = () => {
+    this.props.history.push(this.props.library.url);
+  }
+
+  renderLoading() {
+    const { intl } = this.props;
+
+    return (
+      <LoadingPage loadingMessage={intl.formatMessage(messages['library.edit.loading.message'])} />
+    );
+  }
+
+  renderContent() {
+    const { errorMessage, intl, library } = this.props;
+    const { data } = this.state;
+
+    return (
+      <div className="library-edit-wrapper">
+        <div className="wrapper-mast wrapper">
+          <header className="mast has-actions has-navigation has-subtitle">
+            <div className="page-header">
+              <small className="subtitle">{intl.formatMessage(messages['library.edit.page.heading'])}</small>
+              <h1 className="page-header-title">{library.title}</h1>
+            </div>
+          </header>
+        </div>
+        <div className="wrapper-content wrapper">
+          <section className="content">
+            <article className="content-primary" role="main">
+              {errorMessage
+              && (
+              <Alert
+                variant="danger"
+                onClose={this.handleDismissAlert}
+                dismissible
+              >
+                {truncateErrorMessage(errorMessage)}
+              </Alert>
+              )}
+              <Form onSubmit={this.handleSubmit} className="form-create">
+                <fieldset>
+                  <ol className="list-input">
+                    <li className="field">
+                      <ValidationFormGroup
+                        for="title"
+                        helpText={intl.formatMessage(messages['library.edit.title.help'])}
+                        invalid={this.hasFieldError('title')}
+                        invalidMessage={this.getFieldError('title')}
+                        className="mb-0 mr-2"
+                      >
+                        <label className="h6 d-block" htmlFor="title">
+                          {intl.formatMessage(messages['library.edit.title.label'])}
+                        </label>
+                        <Input
+                          name="title"
+                          id="title"
+                          type="text"
+                          placeholder={intl.formatMessage(messages['library.edit.title.placeholder'])}
+                          defaultValue={data.title}
+                          onChange={this.handleValueChange}
+                        />
+                      </ValidationFormGroup>
+                    </li>
+                    <li className="field">
+                      <ValidationFormGroup
+                        for="description"
+                        helpText={intl.formatMessage(messages['library.edit.description.help'])}
+                        invalid={this.hasFieldError('description')}
+                        invalidMessage={this.getFieldError('description')}
+                        className="mb-0 mr-2"
+                      >
+                        <label className="h6 d-block" htmlFor="description">
+                          {intl.formatMessage(messages['library.edit.description.label'])}
+                        </label>
+                        <Input
+                          name="description"
+                          id="description"
+                          type="textarea"
+                          placeholder={intl.formatMessage(messages['library.edit.description.placeholder'])}
+                          defaultValue={data.description}
+                          onChange={this.handleValueChange}
+                        />
+                      </ValidationFormGroup>
+                    </li>
+                    <li className="field">
+                      <Form.Group>
+                        <Form.Check
+                          type="switch"
+                          id="allow_public_learning"
+                          name="allow_public_learning"
+                          label={intl.formatMessage(messages['library.edit.public_learning.label'])}
+                          checked={data.allow_public_learning}
+                          onChange={this.handleValueChange}
+                          className="coconut"
+                        />
+                        <Form.Check
+                          type="switch"
+                          id="allow_public_read"
+                          name="allow_public_read"
+                          label={intl.formatMessage(messages['library.edit.public_read.label'])}
+                          checked={data.allow_public_read}
+                          onChange={this.handleValueChange}
+                        />
+                      </Form.Group>
+                    </li>
+                  </ol>
+                </fieldset>
+                <div className="actions form-group">
+                  <StatefulButton
+                    variant="primary"
+                    type="submit"
+                    state={this.getSubmitButtonState()}
+                    labels={{
+                      disabled: intl.formatMessage(messages['library.edit.button.submit']),
+                      enabled: intl.formatMessage(messages['library.edit.button.submit']),
+                      pending: intl.formatMessage(messages['library.edit.button.submitting']),
+                    }}
+                    icons={{
+                      pending: <Icon className="fa fa-spinner fa-spin" />,
+                    }}
+                    disabledStates={['disabled', 'pending']}
+                    className="action"
+                  />
+                  <Button
+                    variant="light"
+                    className="action"
+                    onClick={this.handleCancel}
+                  >
+                    {intl.formatMessage(messages['library.edit.button.cancel'])}
+                  </Button>
+                </div>
+              </Form>
+            </article>
+            <aside className="content-supplementary">
+              <div className="bit">
+                <h3 className="title title-3">{intl.formatMessage(messages['library.edit.aside.title'])}</h3>
+                <p>{intl.formatMessage(messages['library.edit.aside.text'])}</p>
+                <ul className="list-actions">
+                  <li className="action-item">
+                    <a
+                      href="http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/course_components/libraries.html"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      {intl.formatMessage(messages['library.edit.aside.help.link'])}
+                    </a>
+                  </li>
+                </ul>
+              </div>
+            </aside>
+          </section>
+        </div>
+      </div>
+    );
+  }
+
+  render() {
+    const { loadingStatus } = this.props;
+
+    let content;
+    if (loadingStatus === LOADING_STATUS.LOADING) {
+      content = this.renderLoading();
+    } else {
+      content = this.renderContent();
+    }
+
+    return (
+      <div className="container-fluid">
+        {content}
+      </div>
+    );
+  }
+}
+
+LibraryEditPage.contextType = AppContext;
+
+LibraryEditPage.propTypes = {
+  clearError: PropTypes.func.isRequired,
+  errorFields: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+  errorMessage: PropTypes.string,
+  fetchLibraryDetail: PropTypes.func.isRequired,
+  history: PropTypes.shape({
+    push: PropTypes.func.isRequired,
+  }).isRequired,
+  intl: intlShape.isRequired,
+  library: libraryShape,
+  match: PropTypes.shape({
+    params: PropTypes.shape({
+      libraryId: PropTypes.string.isRequired,
+    }).isRequired,
+  }).isRequired,
+  loadingStatus: PropTypes.oneOf(Object.values(LOADING_STATUS)).isRequired,
+  submissionStatus: PropTypes.oneOf(Object.values(SUBMISSION_STATUS)).isRequired,
+  updateLibrary: PropTypes.func.isRequired,
+};
+
+LibraryEditPage.defaultProps = libraryEditInitialState;
+
+export default connect(
+  selectLibraryEdit,
+  {
+    clearError,
+    fetchLibraryDetail,
+    updateLibrary,
+  },
+)(injectIntl(withRouter(LibraryEditPage)));

--- a/src/library-authoring/edit-library/data/api.js
+++ b/src/library-authoring/edit-library/data/api.js
@@ -1,0 +1,20 @@
+import { ensureConfig, getConfig } from '@edx/frontend-platform';
+import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+
+ensureConfig(['STUDIO_BASE_URL'], 'library API service');
+
+/* eslint-disable-next-line import/prefer-default-export */
+export async function updateLibrary({ libraryId, ...data }) {
+  const client = getAuthenticatedHttpClient();
+  const baseUrl = getConfig().STUDIO_BASE_URL;
+  await client.patch(
+    `${baseUrl}/api/libraries/v2/${libraryId}/`,
+    data,
+  ).catch((error) => {
+    /* Normalize error data. */
+    const apiError = Object.create(error);
+    apiError.message = null;
+    apiError.fields = JSON.parse(error.customAttributes.httpErrorResponseData);
+    throw apiError;
+  });
+}

--- a/src/library-authoring/edit-library/data/index.js
+++ b/src/library-authoring/edit-library/data/index.js
@@ -1,0 +1,3 @@
+export { default as selectLibraryEdit } from './selectors';
+export * from './slice';
+export * from './thunks';

--- a/src/library-authoring/edit-library/data/selectors.js
+++ b/src/library-authoring/edit-library/data/selectors.js
@@ -1,0 +1,18 @@
+import { createSelector } from 'reselect';
+
+import { selectLibraryDetail } from '../../library-detail';
+import { libraryEditStoreName as storeName } from './slice';
+
+const stateSelector = state => ({ ...state[storeName] });
+
+const selectLibraryEdit = createSelector(
+  stateSelector,
+  selectLibraryDetail,
+  (editState, libraryState) => ({
+    ...editState,
+    library: libraryState.library,
+    loadingStatus: libraryState.status,
+  }),
+);
+
+export default selectLibraryEdit;

--- a/src/library-authoring/edit-library/data/slice.js
+++ b/src/library-authoring/edit-library/data/slice.js
@@ -1,0 +1,39 @@
+/* eslint-disable no-param-reassign */
+import { createSlice } from '@reduxjs/toolkit';
+
+import { LOADING_STATUS, SUBMISSION_STATUS } from '../../common';
+
+export const libraryEditStoreName = 'libraryEdit';
+
+export const libraryEditInitialState = {
+  library: null,
+  errorMessage: null,
+  errorFields: null,
+  loadingStatus: LOADING_STATUS.LOADING,
+  submissionStatus: SUBMISSION_STATUS.UNSUBMITTED,
+};
+
+const slice = createSlice({
+  name: libraryEditStoreName,
+  initialState: libraryEditInitialState,
+  reducers: {
+    libraryUpdateRequest: (state) => {
+      state.submissionStatus = SUBMISSION_STATUS.SUBMITTING;
+    },
+    libraryUpdateSuccess: (state) => {
+      state.submissionStatus = SUBMISSION_STATUS.SUBMITTED;
+    },
+    libraryUpdateFailed: (state, { payload }) => {
+      state.errorMessage = payload.errorMessage;
+      state.errorFields = payload.errorFields;
+      state.submissionStatus = SUBMISSION_STATUS.FAILED;
+    },
+    libraryClearError: (state) => {
+      state.errorMessage = null;
+      state.errorFields = null;
+    },
+  },
+});
+
+export const libraryEditActions = slice.actions;
+export const libraryEditReducer = slice.reducer;

--- a/src/library-authoring/edit-library/data/thunks.js
+++ b/src/library-authoring/edit-library/data/thunks.js
@@ -1,0 +1,18 @@
+import { logError } from '@edx/frontend-platform/logging';
+import * as api from './api';
+import { libraryEditActions as actions } from './slice';
+
+export const updateLibrary = ({ data }) => async (dispatch) => {
+  try {
+    dispatch(actions.libraryUpdateRequest());
+    await api.updateLibrary(data);
+    dispatch(actions.libraryUpdateSuccess());
+  } catch (error) {
+    dispatch(actions.libraryUpdateFailed({ errorMessage: error.message, errorFields: error.fields }));
+    logError(error);
+  }
+};
+
+export const clearError = () => async (dispatch) => {
+  dispatch(actions.libraryEditClearError());
+};

--- a/src/library-authoring/edit-library/index.js
+++ b/src/library-authoring/edit-library/index.js
@@ -1,0 +1,2 @@
+export { default as LibraryEditPage } from './LibraryEditPage';
+export * from './data';

--- a/src/library-authoring/edit-library/messages.js
+++ b/src/library-authoring/edit-library/messages.js
@@ -1,0 +1,86 @@
+import { defineMessages } from '@edx/frontend-platform/i18n';
+
+const messages = defineMessages({
+  'library.edit.loading.message': {
+    id: 'library.edit.loading.message',
+    defaultMessage: 'Loading...',
+    description: 'Message when data is being loaded',
+  },
+  'library.edit.page.heading': {
+    id: 'library.edit.page.heading',
+    defaultMessage: 'Content Library',
+    description: 'The page heading for the library edit page.',
+  },
+  'library.edit.title.label': {
+    id: 'library.edit.title.label',
+    defaultMessage: 'Library Title *',
+    description: 'Label for the title field.',
+  },
+  'library.edit.title.placeholder': {
+    id: 'library.edit.title.placeholder',
+    defaultMessage: 'e.g. Computer Science Problems',
+    description: 'Placeholder text for the title field.',
+  },
+  'library.edit.title.help': {
+    id: 'library.edit.title.help',
+    defaultMessage: 'The title for your library.',
+    description: 'Help text for the title field.',
+  },
+  'library.edit.description.label': {
+    id: 'library.edit.description.label',
+    defaultMessage: 'Library Description *',
+    description: 'Label for the description field.',
+  },
+  'library.edit.description.placeholder': {
+    id: 'library.edit.description.placeholder',
+    defaultMessage: 'e.g. This library contains a collection of CS problems.',
+    description: 'Placeholder text for the description field.',
+  },
+  'library.edit.description.help': {
+    id: 'library.edit.description.help',
+    defaultMessage: 'The description for your library.',
+    description: 'Help text for the description field.',
+  },
+  'library.edit.public_learning.label': {
+    id: 'library.edit.public_learning.label',
+    defaultMessage: 'Allow public learning',
+    description: 'Label for the allow_public_learning field.',
+  },
+  'library.edit.public_read.label': {
+    id: 'library.edit.public_read.label',
+    defaultMessage: 'Allow public read',
+    description: 'Label for the allow_public_read field.',
+  },
+  'library.edit.button.submit': {
+    id: 'library.edit.button.submit',
+    defaultMessage: 'Submit',
+    description: 'Text for the submit button.',
+  },
+  'library.edit.button.submitting': {
+    id: 'library.edit.button.submitting',
+    defaultMessage: 'Submitting',
+    description: 'Text for the submit button when submitting.',
+  },
+  'library.edit.button.cancel': {
+    id: 'library.edit.button.cancel',
+    defaultMessage: 'Cancel',
+    description: 'Text for the cancel button.',
+  },
+  'library.edit.aside.title': {
+    id: 'library.edit.aside.title',
+    defaultMessage: 'Editing your library details',
+    description: 'Title text for the supplementary content.',
+  },
+  'library.edit.aside.text': {
+    id: 'library.edit.aside.text',
+    defaultMessage: 'Edit the details of your library using the form on the left.',
+    description: 'Text for the supplementary content.',
+  },
+  'library.edit.aside.help.link': {
+    id: 'library.edit.aside.help.link',
+    defaultMessage: 'Learn more about content libraries',
+    description: 'Link text for the help link in the supplementary content.',
+  },
+});
+
+export default messages;

--- a/src/library-authoring/index.js
+++ b/src/library-authoring/index.js
@@ -1,6 +1,7 @@
 export * from './common';
 export * from './create-library';
 export * from './edit-block';
+export * from './edit-library';
 export * from './library-detail';
 export * from './list-libraries';
 export * from './studio-header';

--- a/src/library-authoring/library-detail/LibraryDetailPage.jsx
+++ b/src/library-authoring/library-detail/LibraryDetailPage.jsx
@@ -8,8 +8,9 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faPlus } from '@fortawesome/free-solid-svg-icons';
 
 import { LoadingPage } from '../../generic';
-import { LOADING_STATUS, libraryShape } from '../common';
+import { LOADING_STATUS, libraryShape, truncateErrorMessage } from '../common';
 import {
+  clearLibraryError,
   createLibraryBlock,
   commitLibraryChanges,
   fetchLibraryDetail,
@@ -60,6 +61,10 @@ class LibraryDetailPage extends React.Component {
         definition_id: this.state.newBlockSlug,
       },
     });
+  }
+
+  handleDismissAlert = () => {
+    this.props.clearLibraryError();
   }
 
   scrollToAddComponent = () => {
@@ -113,10 +118,11 @@ class LibraryDetailPage extends React.Component {
               && (
               <Alert
                 variant="danger"
-                dialog={errorMessage}
-                onClose={() => {}}
-                open
-              />
+                onClose={this.handleDismissAlert}
+                dismissible
+              >
+                {truncateErrorMessage(errorMessage)}
+              </Alert>
               )}
               <div className="row">
                 {library.blocks && library.blocks.map((block) => (
@@ -249,6 +255,7 @@ class LibraryDetailPage extends React.Component {
 LibraryDetailPage.contextType = AppContext;
 
 LibraryDetailPage.propTypes = {
+  clearLibraryError: PropTypes.func.isRequired,
   commitLibraryChanges: PropTypes.func.isRequired,
   createLibraryBlock: PropTypes.func.isRequired,
   errorMessage: PropTypes.string,
@@ -269,6 +276,7 @@ LibraryDetailPage.defaultProps = libraryDetailInitialState;
 export default connect(
   selectLibraryDetail,
   {
+    clearLibraryError,
     createLibraryBlock,
     commitLibraryChanges,
     revertLibraryChanges,

--- a/src/library-authoring/library-detail/LibraryPage.jsx
+++ b/src/library-authoring/library-detail/LibraryPage.jsx
@@ -21,7 +21,7 @@ import {
 import LibraryBlockCard from './LibraryBlockCard';
 import messages from './messages';
 
-class LibraryDetailPage extends React.Component {
+class LibraryPage extends React.Component {
   constructor(props) {
     super(props);
     this.addComponentRef = React.createRef();
@@ -252,9 +252,9 @@ class LibraryDetailPage extends React.Component {
   }
 }
 
-LibraryDetailPage.contextType = AppContext;
+LibraryPage.contextType = AppContext;
 
-LibraryDetailPage.propTypes = {
+LibraryPage.propTypes = {
   clearLibraryError: PropTypes.func.isRequired,
   commitLibraryChanges: PropTypes.func.isRequired,
   createLibraryBlock: PropTypes.func.isRequired,
@@ -271,7 +271,7 @@ LibraryDetailPage.propTypes = {
   status: PropTypes.oneOf(Object.values(LOADING_STATUS)).isRequired,
 };
 
-LibraryDetailPage.defaultProps = libraryDetailInitialState;
+LibraryPage.defaultProps = libraryDetailInitialState;
 
 export default connect(
   selectLibraryDetail,
@@ -282,4 +282,4 @@ export default connect(
     revertLibraryChanges,
     fetchLibraryDetail,
   },
-)(injectIntl(LibraryDetailPage));
+)(injectIntl(LibraryPage));

--- a/src/library-authoring/library-detail/data/slice.js
+++ b/src/library-authoring/library-detail/data/slice.js
@@ -28,6 +28,9 @@ const slice = createSlice({
       state.errorMessage = payload.errorMessage;
       state.status = LOADING_STATUS.FAILED;
     },
+    libraryDetailClearError: (state) => {
+      state.errorMessage = null;
+    },
     libraryCreateBlockSuccess: (state, { payload }) => {
       state.errorMessage = null;
       state.status = LOADING_STATUS.LOADED;

--- a/src/library-authoring/library-detail/data/thunks.js
+++ b/src/library-authoring/library-detail/data/thunks.js
@@ -47,3 +47,7 @@ export const revertLibraryChanges = ({ libraryId }) => async (dispatch) => {
     logError(error);
   }
 };
+
+export const clearLibraryError = () => async (dispatch) => {
+  dispatch(actions.libraryDetailClearError());
+};

--- a/src/library-authoring/library-detail/index.js
+++ b/src/library-authoring/library-detail/index.js
@@ -1,2 +1,2 @@
-export { default as LibraryDetailPage } from './LibraryDetailPage';
+export { default as LibraryPage } from './LibraryPage';
 export * from './data';

--- a/src/library-authoring/list-libraries/data/api.js
+++ b/src/library-authoring/list-libraries/data/api.js
@@ -5,15 +5,22 @@ import { LIBRARY_TYPES, unpackLibraryKey } from '../../common';
 
 ensureConfig(['STUDIO_BASE_URL'], 'library API service');
 
-/* eslint-disable-next-line import/prefer-default-export */
-export async function getLibraryList() {
+export async function getOrgList() {
+  const client = getAuthenticatedHttpClient();
+  const baseUrl = getConfig().STUDIO_BASE_URL;
+  const response = await client.get(`${baseUrl}/organizations`);
+
+  return response.data;
+}
+
+export async function getLibraryList(params) {
   const client = getAuthenticatedHttpClient();
   const baseUrl = getConfig().STUDIO_BASE_URL;
 
   /* Fetch modulestore and blockstore libraries simultaneously. */
   const [v1Response, v2Response] = await Promise.all([
-    client.get(`${baseUrl}/library/`),
-    client.get(`${baseUrl}/api/libraries/v2/`),
+    client.get(`${baseUrl}/library/`, { params }),
+    client.get(`${baseUrl}/api/libraries/v2/`, { params }),
   ]);
 
   /* Normalize modulestore properties to conform to the v2 API, marking them as

--- a/src/library-authoring/list-libraries/data/slice.js
+++ b/src/library-authoring/list-libraries/data/slice.js
@@ -8,6 +8,7 @@ export const libraryListStoreName = 'libraryList';
 export const libraryListInitialState = {
   errorMessage: null,
   libraries: [],
+  orgs: [],
   status: LOADING_STATUS.LOADING,
 };
 
@@ -20,6 +21,7 @@ const slice = createSlice({
     },
     libraryListSuccess: (state, { payload }) => {
       state.libraries = payload.libraries;
+      state.orgs = payload.orgs;
       state.status = LOADING_STATUS.LOADED;
     },
     libraryListFailed: (state, { payload }) => {

--- a/src/library-authoring/list-libraries/data/thunks.js
+++ b/src/library-authoring/list-libraries/data/thunks.js
@@ -2,11 +2,14 @@ import { logError } from '@edx/frontend-platform/logging';
 import * as api from './api';
 import { libraryListActions as actions } from './slice';
 
-const fetchLibraryList = () => async (dispatch) => {
+const fetchLibraryList = ({ params }) => async (dispatch) => {
   try {
     dispatch(actions.libraryListRequest());
-    const libraries = await api.getLibraryList();
-    dispatch(actions.libraryListSuccess({ libraries }));
+    const [libraries, orgs] = await Promise.all([
+      api.getLibraryList(params),
+      api.getOrgList(),
+    ]);
+    dispatch(actions.libraryListSuccess({ libraries, orgs }));
   } catch (error) {
     dispatch(actions.libraryListFailed({ errorMessage: error.message }));
     logError(error);

--- a/src/library-authoring/list-libraries/index.scss
+++ b/src/library-authoring/list-libraries/index.scss
@@ -110,4 +110,15 @@
       }
     }
   }
+
+  .filter-form {
+    .form-label {
+      font-weight: 600;
+    }
+
+    button,
+    .form-control {
+      font-size: 1.4rem;
+    }
+  }
 }

--- a/src/library-authoring/list-libraries/messages.js
+++ b/src/library-authoring/list-libraries/messages.js
@@ -46,6 +46,31 @@ const messages = defineMessages({
     defaultMessage: 'Library slug:',
     description: 'Label of the library slug metadata item',
   },
+  'library.list.filter.title': {
+    id: 'library.list.filter.title',
+    defaultMessage: 'Find a library',
+    description: 'Title text for the filter box.',
+  },
+  'library.list.filter.input.default': {
+    id: 'library.list.filter.input.default',
+    defaultMessage: 'Enter ID, title, or organization.',
+    description: 'Default value for the filter input field.',
+  },
+  'library.list.filter.options.org.label': {
+    id: 'library.list.filter.options.org.label',
+    defaultMessage: 'Organization',
+    description: 'Label for the organization form group.',
+  },
+  'library.list.filter.options.org.all': {
+    id: 'library.list.filter.options.org.all',
+    defaultMessage: 'All',
+    description: 'Label for the empty organization option.',
+  },
+  'library.list.filter.options.org.organizations': {
+    id: 'library.list.filter.options.org.organizations',
+    defaultMessage: 'Organizations',
+    description: 'Label for the main organization option group.',
+  },
   'library.list.aside.title': {
     id: 'library.list.aside.title',
     defaultMessage: 'New to Studio?',

--- a/src/library-authoring/studio-header/StudioHeader.jsx
+++ b/src/library-authoring/studio-header/StudioHeader.jsx
@@ -63,13 +63,14 @@ const StudioHeader = ({ intl, library }) => {
               </li>
               <li className="nav-item nav-account-user">
                 <Dropdown>
-                  <Dropdown.Toggle>
+                  <Dropdown.Toggle variant="outline-light">
                     {authenticatedUser.username}
                     <Icon className="fa fa-caret-down pl-3" alt="" />
                   </Dropdown.Toggle>
-                  <Dropdown.Menu>
-                    <Dropdown.Item href={config.STUDIO_BASE_URL}>{intl.formatMessage(messages['library.header.account.studiohome'])}</Dropdown.Item>
-                    <Dropdown.Item href={config.LOGOUT_URL}>{intl.formatMessage(messages['library.header.account.signout'])}</Dropdown.Item>
+                  <Dropdown.Menu className="dropdown-menu-right p-4 mt-3 fade">
+                    <Dropdown.Item className="p-0 mb-3" href={config.STUDIO_BASE_URL}>{intl.formatMessage(messages['library.header.account.studiohome'])}</Dropdown.Item>
+                    <Dropdown.Item className="p-0 mb-3" href={`${config.STUDIO_BASE_URL}/maintenance`}>{intl.formatMessage(messages['library.header.account.maintenance'])}</Dropdown.Item>
+                    <Dropdown.Item className="p-0" href={config.LOGOUT_URL}>{intl.formatMessage(messages['library.header.account.signout'])}</Dropdown.Item>
                   </Dropdown.Menu>
                 </Dropdown>
               </li>

--- a/src/library-authoring/studio-header/StudioHeader.jsx
+++ b/src/library-authoring/studio-header/StudioHeader.jsx
@@ -6,7 +6,7 @@ import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import { AppContext } from '@edx/frontend-platform/react';
 import { ensureConfig } from '@edx/frontend-platform/config';
 
-import { libraryShape } from '../common';
+import { ROUTES, libraryShape } from '../common';
 import { selectLibraryDetail } from '../library-detail';
 import StudioLogo from './assets/studio-logo.png';
 import messages from './messages';
@@ -34,20 +34,33 @@ const StudioHeader = ({ intl, library }) => {
           <Route path="/library">
             {library
             && (
-            <h2 className="info-library">
-              <Link to={library.url} className="library-link">
-                <span className="library-org">{library.org}</span>
-                <span className="library-id">{library.id}</span>
-                <span className="library-title" title={library.title}>{library.title}</span>
-              </Link>
-            </h2>
+              <>
+                <h2 className="info-library">
+                  <Link to={library.url} className="library-link">
+                    <span className="library-org">{library.org}</span>
+                    <span className="library-id">{library.id}</span>
+                    <span className="library-title" title={library.title}>{library.title}</span>
+                  </Link>
+                </h2>
+                <nav className="p-4 mt-2">
+                  <Dropdown>
+                    <Dropdown.Toggle variant="outline-light">
+                      {intl.formatMessage(messages['library.header.settings.menu'])}
+                      <Icon className="fa fa-caret-down pl-3" alt="" />
+                    </Dropdown.Toggle>
+                    <Dropdown.Menu className="p-4 mt-1 fade">
+                      <Dropdown.Item className="p-0" as={Link} to={ROUTES.Detail.EDIT_SLUG(library.id)}>{intl.formatMessage(messages['library.header.settings.details'])}</Dropdown.Item>
+                    </Dropdown.Menu>
+                  </Dropdown>
+                </nav>
+              </>
             )}
           </Route>
         </div>
         <div className="wrapper-r">
           {authenticatedUser !== null
           && (
-          <nav className="nav-account" aria-label={intl.formatMessage(messages['library.header.account.label'])}>
+          <nav className="p-4 mt-2" aria-label={intl.formatMessage(messages['library.header.account.label'])}>
             <ol>
               <li className="nav-item nav-account-help">
                 <h3 className="title">
@@ -67,7 +80,7 @@ const StudioHeader = ({ intl, library }) => {
                     {authenticatedUser.username}
                     <Icon className="fa fa-caret-down pl-3" alt="" />
                   </Dropdown.Toggle>
-                  <Dropdown.Menu className="dropdown-menu-right p-4 mt-3 fade">
+                  <Dropdown.Menu className="dropdown-menu-right p-4 mt-1 fade">
                     <Dropdown.Item className="p-0 mb-3" href={config.STUDIO_BASE_URL}>{intl.formatMessage(messages['library.header.account.studiohome'])}</Dropdown.Item>
                     <Dropdown.Item className="p-0 mb-3" href={`${config.STUDIO_BASE_URL}/maintenance`}>{intl.formatMessage(messages['library.header.account.maintenance'])}</Dropdown.Item>
                     <Dropdown.Item className="p-0" href={config.LOGOUT_URL}>{intl.formatMessage(messages['library.header.account.signout'])}</Dropdown.Item>

--- a/src/library-authoring/studio-header/index.scss
+++ b/src/library-authoring/studio-header/index.scss
@@ -60,7 +60,7 @@
         font-weight: 600;
         background-color: white;
         color: $gray-d1;
-        border: 0;
+        border-width: 1px;
         line-height: 2.368rem;
 
         &:hover {
@@ -69,8 +69,48 @@
       }
 
       .dropdown-menu {
-        font-size: 1.2rem;
-        padding: 0;
+        font-size: 1.4rem;
+        width: 160px;
+
+      }
+
+      // This is a dirty fix for a Bootstrap positioning bug that breaks right menu alignment on certain screen widths.
+      .dropdown-menu-right.show {
+        inset: 0px 0px auto auto !important;
+        transform: translate(0px, 43px) !important;
+      }
+
+      .dropdown-menu:before {
+        position: absolute;
+        top: -11px;
+        left: 9px;
+        display: inline-block;
+        border-right: 11px solid transparent;
+        border-bottom: 11px solid #CCC;
+        border-left: 11px solid transparent;
+        border-bottom-color: rgba(0, 0, 0, 0.2);
+        content: '';
+      }
+
+      .dropdown-menu:after {
+        position: absolute;
+        top: -10px;
+        left: 10px;
+        display: inline-block;
+        border-right: 10px solid transparent;
+        border-bottom: 10px solid white;
+        border-left: 10px solid transparent;
+        content: '';
+      }
+
+      .dropdown-menu:before, .dropdown-menu.pull-right:before {
+        right: 12px;
+        left: auto;
+      }
+
+      .dropdown-menu::after, .dropdown-menu.pull-right:after {
+        right: 13px;
+        left: auto;
       }
     }
 

--- a/src/library-authoring/studio-header/index.scss
+++ b/src/library-authoring/studio-header/index.scss
@@ -31,6 +31,7 @@
 
   .wrapper-l {
     @include float(left);
+    width: 74.46809%;
   }
 
   .wrapper-r {
@@ -71,46 +72,11 @@
       .dropdown-menu {
         font-size: 1.4rem;
         width: 160px;
-
       }
 
-      // This is a dirty fix for a Bootstrap positioning bug that breaks right menu alignment on certain screen widths.
-      .dropdown-menu-right.show {
-        inset: 0px 0px auto auto !important;
-        transform: translate(0px, 43px) !important;
-      }
-
-      .dropdown-menu:before {
-        position: absolute;
-        top: -11px;
-        left: 9px;
-        display: inline-block;
-        border-right: 11px solid transparent;
-        border-bottom: 11px solid #CCC;
-        border-left: 11px solid transparent;
-        border-bottom-color: rgba(0, 0, 0, 0.2);
-        content: '';
-      }
-
-      .dropdown-menu:after {
-        position: absolute;
-        top: -10px;
-        left: 10px;
-        display: inline-block;
-        border-right: 10px solid transparent;
-        border-bottom: 10px solid white;
-        border-left: 10px solid transparent;
-        content: '';
-      }
-
-      .dropdown-menu:before, .dropdown-menu.pull-right:before {
-        right: 12px;
-        left: auto;
-      }
-
-      .dropdown-menu::after, .dropdown-menu.pull-right:after {
-        right: 13px;
-        left: auto;
+      .dropdown-item:active {
+        color: $uxpl-blue-hover-active;
+        background-color: white;
       }
     }
 
@@ -169,7 +135,7 @@
   .info-library {
     @include margin-right(2%);
     @include border-right(1px solid $gray-l4);
-    width: 50%;
+    width: 25%;
     padding: ($baseline*0.75) 2% ($baseline*0.75) 0;
 
     .library-org,

--- a/src/library-authoring/studio-header/messages.js
+++ b/src/library-authoring/studio-header/messages.js
@@ -6,6 +6,16 @@ const messages = defineMessages({
     defaultMessage: 'Content Libraries',
     description: 'Alt text for the the header logo.',
   },
+  'library.header.settings.menu': {
+    id: 'library.header.settings.menu',
+    defaultMessage: 'Settings',
+    description: 'Title text for the settings menu.',
+  },
+  'library.header.settings.details': {
+    id: 'library.header.settings.details',
+    defaultMessage: 'Details',
+    description: 'Text for the details item in the settings menu.',
+  },
   'library.header.nav.help.title': {
     id: 'library.header.nav.help.title',
     defaultMessage: 'Online Help',

--- a/src/library-authoring/studio-header/messages.js
+++ b/src/library-authoring/studio-header/messages.js
@@ -36,6 +36,11 @@ const messages = defineMessages({
     defaultMessage: 'Studio Home',
     description: 'Text for link to studio.',
   },
+  'library.header.account.maintenance': {
+    id: 'library.header.account.maintenance',
+    defaultMessage: 'Maintenance',
+    description: 'Text for link to maintenance.',
+  },
   'library.header.account.signout': {
     id: 'library.header.account.signout',
     defaultMessage: 'Sign Out',

--- a/src/store.js
+++ b/src/store.js
@@ -4,6 +4,8 @@ import {
   libraryBlockStoreName,
   libraryDetailReducer,
   libraryDetailStoreName,
+  libraryEditReducer,
+  libraryEditStoreName,
   libraryCreateReducer,
   libraryCreateStoreName,
   libraryListReducer,
@@ -14,6 +16,7 @@ const store = configureStore({
   reducer: {
     [libraryBlockStoreName]: libraryBlockReducer,
     [libraryDetailStoreName]: libraryDetailReducer,
+    [libraryEditStoreName]: libraryEditReducer,
     [libraryCreateStoreName]: libraryCreateReducer,
     [libraryListStoreName]: libraryListReducer,
   },

--- a/src/vendor/overrides.scss
+++ b/src/vendor/overrides.scss
@@ -12,3 +12,9 @@ $font-family-sans-serif: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-s
 .footer {
   background-color: transparent;
 }
+
+.container-fluid {
+  max-width: 1280px;
+  padding-left: 0;
+  padding-right: 0;
+}

--- a/src/vendor/studio.scss
+++ b/src/vendor/studio.scss
@@ -1111,7 +1111,7 @@ button {
 
 .wrapper-mast {
   margin: ($baseline*1.5) 0 0 0;
-  padding: 0 $baseline;
+  padding: 0;
   position: relative;
 
   .mast,
@@ -1195,7 +1195,7 @@ button {
 
 .wrapper-content {
   margin: 0;
-  padding: 0 $baseline;
+  padding: 0;
   position: relative;
 }
 


### PR DESCRIPTION
#### Description

This introduces:

* Fixes for the remaining Paragon upgrade issues
* A fix for assets not showing immediately after being uploaded
* A header account dropdown menu that better matches Studio design
* Library list filtering
* Editing of library details

#### Manual testing

1. Follow the manual testing instructions in https://github.com/edx/frontend-app-library-authoring/pull/4 until step 16, so that you have a v2 library to work with.  Use this PR's branch (`arbrandes/filtering-and-details`), though.

1. If https://github.com/edx/edx-platform/pull/24510 hasn't been merged when testing this, check that PR out and restart Studio.  Otherwise, filtering won't work.

1. Make sure the `ORGANIZATIONS_APP` feature flag is set to `true` for Studio.  In the latest devstack, that is the default.  If unset, the org filter dropdown won't work.

1. In the library page of the library you just created, click on Settings > Details.

    <details>
    <summary>Screenshot</summary>

    ![Screenshot_2020-08-22_22-55-32](https://user-images.githubusercontent.com/759355/90969094-c81b9900-e4ca-11ea-88e3-2950fc9aacde.png)
    </details>

1. Edit it as you see fit, then press submit.

    <details>
    <summary>Screenshot</summary>

    ![Screenshot_2020-08-22_23-02-59](https://user-images.githubusercontent.com/759355/90969148-b686c100-e4cb-11ea-845e-8e1fffa31694.png)
    </details>

1. You will be taken back to the library page.  If you changed the title, you should see the new one here.

1. Go back to the library list, and create a few libraries.  Also create a second organization, and put some libraries in there.  Finally, use the filter fields on the right and check that the right libraries are being shown.

    <details>
    <summary>Screenshot</summary>

    ![Screenshot_2020-08-22_23-10-20](https://user-images.githubusercontent.com/759355/90969259-d8347800-e4cc-11ea-8bb6-7aaf47e35fd1.png)
    </details>