### PR TITLE
[BD-14] SE-2946: Add support for Video and Problem library types.

### DIFF
--- a/src/library-authoring/common/data/constants.js
+++ b/src/library-authoring/common/data/constants.js
@@ -1,4 +1,6 @@
 export const LIBRARY_TYPES = {
+  VIDEO: 'video', // blockstore/v2
+  PROBLEM: 'problem', // blockstore/v2
   COMPLEX: 'complex', // blockstore/v2
   LEGACY: 'legacy', // modulestore/v1
 };

--- a/src/library-authoring/create-library/LibraryCreateForm.jsx
+++ b/src/library-authoring/create-library/LibraryCreateForm.jsx
@@ -51,10 +51,10 @@ class LibraryCreateForm extends React.Component {
       && createdLibrary !== prevProps.createdLibrary
       && createdLibrary !== null
     ) {
-      if (createdLibrary.type === LIBRARY_TYPES.COMPLEX) {
-        this.props.history.push(createdLibrary.url);
-      } else if (createdLibrary.type === LIBRARY_TYPES.LEGACY) {
+      if (createdLibrary.type === LIBRARY_TYPES.LEGACY) {
         window.location.href = createdLibrary.url;
+      } else if (Object.values(LIBRARY_TYPES).includes(createdLibrary.type)) {
+        this.props.history.push(createdLibrary.url);
       }
     }
   }

--- a/src/library-authoring/create-library/data/api.js
+++ b/src/library-authoring/create-library/data/api.js
@@ -15,23 +15,7 @@ export async function createLibrary({ type, ...data }) {
 
   let response;
   let library;
-  if (type === LIBRARY_TYPES.COMPLEX) {
-    response = await client.post(`${STUDIO_BASE_URL}/api/libraries/v2/`, {
-      ...data,
-      description: data.title,
-      collection_uuid: BLOCKSTORE_COLLECTION_UUID,
-    }).catch((error) => {
-      /* Normalize error data. */
-      const apiError = Object.create(error);
-      apiError.message = null;
-      apiError.fields = JSON.parse(error.customAttributes.httpErrorResponseData);
-      throw apiError;
-    });
-    library = {
-      ...response.data,
-      type,
-    };
-  } else if (type === LIBRARY_TYPES.LEGACY) {
+  if (type === LIBRARY_TYPES.LEGACY) {
     response = await client.post(`${STUDIO_BASE_URL}/library/`, {
       org: data.org,
       number: data.slug,
@@ -51,8 +35,25 @@ export async function createLibrary({ type, ...data }) {
       title: data.title,
       description: null,
       version: null,
+      type: LIBRARY_TYPES.LEGACY,
       has_unpublished_changes: false,
       has_unpublished_deletes: false,
+    };
+  } else if (Object.values(LIBRARY_TYPES).includes(type)) {
+    response = await client.post(`${STUDIO_BASE_URL}/api/libraries/v2/`, {
+      ...data,
+      type,
+      description: data.title,
+      collection_uuid: BLOCKSTORE_COLLECTION_UUID,
+    }).catch((error) => {
+      /* Normalize error data. */
+      const apiError = Object.create(error);
+      apiError.message = null;
+      apiError.fields = JSON.parse(error.customAttributes.httpErrorResponseData);
+      throw apiError;
+    });
+    library = {
+      ...response.data,
       type,
     };
   } else {

--- a/src/library-authoring/create-library/messages.js
+++ b/src/library-authoring/create-library/messages.js
@@ -73,9 +73,19 @@ const messages = defineMessages({
     defaultMessage: 'Cancel',
     description: 'Text for the cancel button.',
   },
+  'library.form.type.label.video': {
+    id: 'library.form.type.label.video',
+    defaultMessage: 'Video (beta)',
+    description: 'Label for the video library type.',
+  },
+  'library.form.type.label.problem': {
+    id: 'library.form.type.label.problem',
+    defaultMessage: 'Problem (beta)',
+    description: 'Label for the problem library type.',
+  },
   'library.form.type.label.complex': {
     id: 'library.form.type.label.complex',
-    defaultMessage: 'Complex',
+    defaultMessage: 'Complex (beta)',
     description: 'Label for the complex library type.',
   },
   'library.form.type.label.legacy': {

--- a/src/library-authoring/edit-library/LibraryEditPage.jsx
+++ b/src/library-authoring/edit-library/LibraryEditPage.jsx
@@ -19,7 +19,7 @@ import {
   LOADING_STATUS,
   SUBMISSION_STATUS,
   libraryShape,
-  truncateErrorMessage,
+  truncateErrorMessage, LIBRARY_TYPES,
 } from '../common';
 import {
   fetchLibraryDetail,
@@ -37,9 +37,10 @@ class LibraryEditPage extends React.Component {
     super(props);
     this.state = {
       data: {
-        id: null,
+        libraryId: null,
         title: '',
         description: '',
+        type: null,
         allow_public_learning: false,
         allow_public_read: false,
       },
@@ -75,6 +76,7 @@ class LibraryEditPage extends React.Component {
         libraryId: library.id,
         title: library.title,
         description: library.description,
+        type: library.type,
         allow_public_learning: library.allow_public_learning,
         allow_public_read: library.allow_public_read,
       },
@@ -143,6 +145,10 @@ class LibraryEditPage extends React.Component {
     this.props.updateLibrary({ data: this.state.data });
   }
 
+  componentWillUnmount = () => {
+    this.props.clearError();
+  }
+
   handleCancel = () => {
     this.props.history.push(this.props.library.url);
   }
@@ -158,6 +164,11 @@ class LibraryEditPage extends React.Component {
   renderContent() {
     const { errorMessage, intl, library } = this.props;
     const { data } = this.state;
+
+    const validTypes = Object.values(LIBRARY_TYPES).filter((type) => type !== LIBRARY_TYPES.LEGACY);
+    const typeOptions = validTypes.map((value) => (
+      { value, label: intl.formatMessage(messages[`library.edit.type.label.${value}`]) }
+    ));
 
     return (
       <div className="library-edit-wrapper">
@@ -226,6 +237,28 @@ class LibraryEditPage extends React.Component {
                           onChange={this.handleValueChange}
                         />
                       </ValidationFormGroup>
+                    </li>
+                    <li className="field">
+                      {data.libraryId && (
+                        <ValidationFormGroup
+                          for="type"
+                          helpText={intl.formatMessage(messages['library.edit.type.help'])}
+                          invalid={this.hasFieldError('type')}
+                          invalidMessage={this.getFieldError('type')}
+                          className="mb-0 mr-2"
+                        >
+                          <label className="h6 d-block" htmlFor="type">
+                            {intl.formatMessage(messages['library.edit.type.label'])}
+                          </label>
+                          <Input
+                            name="type"
+                            type="select"
+                            options={typeOptions}
+                            defaultValue={data.type}
+                            onChange={this.handleValueChange}
+                          />
+                        </ValidationFormGroup>
+                      ) }
                     </li>
                     <li className="field">
                       <Form.Group>

--- a/src/library-authoring/edit-library/data/thunks.js
+++ b/src/library-authoring/edit-library/data/thunks.js
@@ -14,5 +14,5 @@ export const updateLibrary = ({ data }) => async (dispatch) => {
 };
 
 export const clearError = () => async (dispatch) => {
-  dispatch(actions.libraryEditClearError());
+  dispatch(actions.libraryClearError());
 };

--- a/src/library-authoring/edit-library/messages.js
+++ b/src/library-authoring/edit-library/messages.js
@@ -41,6 +41,31 @@ const messages = defineMessages({
     defaultMessage: 'The description for your library.',
     description: 'Help text for the description field.',
   },
+  'library.edit.type.label': {
+    id: 'library.edit.type.label',
+    defaultMessage: 'Library Type *',
+    description: 'Label for the type field.',
+  },
+  'library.edit.type.help': {
+    id: 'library.edit.type.help',
+    defaultMessage: 'The type of library.',
+    description: 'Help text for the type field.',
+  },
+  'library.edit.type.label.video': {
+    id: 'library.edit.type.label.video',
+    defaultMessage: 'Video (beta)',
+    description: 'Label for the video library type.',
+  },
+  'library.edit.type.label.problem': {
+    id: 'library.edit.type.label.problem',
+    defaultMessage: 'Problem (beta)',
+    description: 'Label for the problem library type.',
+  },
+  'library.edit.type.label.complex': {
+    id: 'library.edit.type.label.complex',
+    defaultMessage: 'Complex (beta)',
+    description: 'Label for the complex library type.',
+  },
   'library.edit.public_learning.label': {
     id: 'library.edit.public_learning.label',
     defaultMessage: 'Allow public learning',

--- a/src/library-authoring/library-detail/LibraryPage.jsx
+++ b/src/library-authoring/library-detail/LibraryPage.jsx
@@ -36,6 +36,16 @@ class LibraryPage extends React.Component {
     this.props.fetchLibraryDetail({ libraryId });
   }
 
+  componentDidUpdate(prevProps) {
+    const oldBlockTypes = (prevProps.library && prevProps.library.blockTypes) || [];
+    const newBlockTypes = (this.props.library && this.props.library.blockTypes) || [];
+    // Identity check is good enough here. In all current scenarios it should have the same effect as deep equality
+    // checking. Might change this if we suddenly allow switching libraries in place from this page.
+    if ((oldBlockTypes !== newBlockTypes) && newBlockTypes.length) {
+      this.updateBlockDefault();
+    }
+  }
+
   handleCommitChanges = () => {
     this.props.commitLibraryChanges({ libraryId: this.props.library.id });
   }
@@ -72,6 +82,16 @@ class LibraryPage extends React.Component {
       this.addComponentRef.current.scrollIntoView({
         behaviour: 'smooth',
       });
+    }
+  }
+
+  updateBlockDefault() {
+    // The default block type is 'html', but this will break the form if we're in a video or problem library.
+    // In the case we're in one of those, the server should only return one valid block type, which we can then set.
+    const { library } = this.props;
+    const currentBlockValid = !!library.blockTypes.filter((type) => type.block_type === this.state.newBlockType).length;
+    if (library.blockTypes.length && !currentBlockValid) {
+      this.setState({ newBlockType: library.blockTypes[0].block_type });
     }
   }
 

--- a/src/library-authoring/library-detail/data/api.js
+++ b/src/library-authoring/library-detail/data/api.js
@@ -1,8 +1,6 @@
 import { ensureConfig, getConfig } from '@edx/frontend-platform';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 
-import { LIBRARY_TYPES } from '../../common';
-
 ensureConfig(['STUDIO_BASE_URL'], 'library API service');
 
 export async function getLibraryDetail(libraryId) {
@@ -23,7 +21,6 @@ export async function getLibraryDetail(libraryId) {
     ...detailResponse.data,
     blocks: blockResponse.data,
     blockTypes: blockTypeResponse.data,
-    type: LIBRARY_TYPES.COMPLEX,
   };
 
   return library;

--- a/src/library-authoring/list-libraries/LibraryListPage.jsx
+++ b/src/library-authoring/list-libraries/LibraryListPage.jsx
@@ -8,7 +8,9 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faPlus, faSearch } from '@fortawesome/free-solid-svg-icons';
 
 import { LoadingPage } from '../../generic';
-import { LOADING_STATUS, LibraryIndexTabs, libraryShape } from '../common';
+import {
+  LOADING_STATUS, LibraryIndexTabs, libraryShape, LIBRARY_TYPES,
+} from '../common';
 import { LibraryCreateForm } from '../create-library';
 import {
   fetchLibraryList,
@@ -67,6 +69,16 @@ class LibraryListPage extends React.Component {
     });
   }
 
+  handleFilterTypeChange = (event) => {
+    this.handleFilterChange(event);
+    this.props.fetchLibraryList({
+      params: {
+        ...this.state.filterParams,
+        type: event.target.value,
+      },
+    });
+  }
+
   handleFilterSubmit = (event) => {
     event.preventDefault();
     this.props.fetchLibraryList({ params: this.state.filterParams });
@@ -107,6 +119,14 @@ class LibraryListPage extends React.Component {
         })),
       },
     ];
+
+    const typeOptions = [{
+      label: intl.formatMessage(messages['library.list.filter.options.type.types']),
+      group: Object.values(LIBRARY_TYPES).map((value) => (
+        { value, label: intl.formatMessage(messages[`library.list.filter.options.type.${value}`]) }
+      )),
+    }];
+    typeOptions.unshift({ value: '', label: intl.formatMessage(messages['library.list.filter.options.type.all']) });
 
     return (
       <div className="library-list-wrapper">
@@ -193,6 +213,20 @@ class LibraryListPage extends React.Component {
                         options={orgOptions}
                         defaultValue={filterParams ? filterParams.org : null}
                         onChange={this.handleFilterOrgChange}
+                      />
+                    </Form.Group>
+                  </Form.Row>
+                  <Form.Row>
+                    <Form.Group className="w-100">
+                      <Form.Label className="title title-3">
+                        {intl.formatMessage(messages['library.list.filter.options.type.label'])}
+                      </Form.Label>
+                      <Input
+                        name="type"
+                        type="select"
+                        options={typeOptions}
+                        defaultValue={filterParams ? filterParams.type : null}
+                        onChange={this.handleFilterTypeChange}
                       />
                     </Form.Group>
                   </Form.Row>

--- a/src/library-authoring/list-libraries/messages.js
+++ b/src/library-authoring/list-libraries/messages.js
@@ -26,9 +26,19 @@ const messages = defineMessages({
     defaultMessage: 'Type:',
     description: 'Label of the library type metadata item',
   },
+  'library.list.item.type.video': {
+    id: 'library.list.item.type.video',
+    defaultMessage: 'Video (beta)',
+    description: 'Label for the video library type.',
+  },
+  'library.list.item.type.problem': {
+    id: 'library.list.item.type.problem',
+    defaultMessage: 'Problem (beta)',
+    description: 'Label for the problem library type.',
+  },
   'library.list.item.type.complex': {
     id: 'library.list.item.type.complex',
-    defaultMessage: 'Complex',
+    defaultMessage: 'Complex (beta)',
     description: 'Label for the complex library type.',
   },
   'library.list.item.type.legacy': {
@@ -70,6 +80,41 @@ const messages = defineMessages({
     id: 'library.list.filter.options.org.organizations',
     defaultMessage: 'Organizations',
     description: 'Label for the main organization option group.',
+  },
+  'library.list.filter.options.type.label': {
+    id: 'library.list.filter.options.type.label',
+    defaultMessage: 'Type',
+    description: 'Label for the type form group.',
+  },
+  'library.list.filter.options.type.all': {
+    id: 'library.list.filter.options.type.all',
+    defaultMessage: 'All',
+    description: 'Label for the empty type option.',
+  },
+  'library.list.filter.options.type.types': {
+    id: 'library.list.filter.options.type.types',
+    defaultMessage: 'Types',
+    description: 'Label for the main type option group.',
+  },
+  'library.list.filter.options.type.legacy': {
+    id: 'library.list.filter.options.type.legacy',
+    defaultMessage: 'Legacy',
+    description: 'Label for the legacy type option.',
+  },
+  'library.list.filter.options.type.complex': {
+    id: 'library.list.filter.options.type.complex',
+    defaultMessage: 'Complex (beta)',
+    description: 'Label for the complex type option.',
+  },
+  'library.list.filter.options.type.video': {
+    id: 'library.list.filter.options.type.video',
+    defaultMessage: 'Video (beta)',
+    description: 'Label for the video type option.',
+  },
+  'library.list.filter.options.type.problem': {
+    id: 'library.list.filter.options.type.problem',
+    defaultMessage: 'Problem (beta)',
+    description: 'Label for the video type option.',
   },
   'library.list.aside.title': {
     id: 'library.list.aside.title',


### PR DESCRIPTION
Adds support for library types, adding the 'video' and 'problem' type, and permitting filtering by these types.

**Discussions**: https://docs.google.com/document/d/1hRrSmWWlGHhi-bh9AIlpSuLtJFnn2GpavNe8OQxthbE/edit

**Dependencies**: https://github.com/edx/frontend-app-library-authoring/pull/7 must be merged first-- this PR includes the code from it. To review only the code from this PR, a convenience PR has been created here: https://github.com/open-craft/frontend-app-library-authoring/pull/1

**Screenshots**:

Creation page changes:

<img width="983" alt="image" src="https://user-images.githubusercontent.com/1099483/91499806-c3b6fd80-e887-11ea-841a-443ed6f3fdd8.png">

Edit Details:

<img width="983" alt="image" src="https://user-images.githubusercontent.com/1099483/91500546-5c01b200-e889-11ea-9447-04d5f29afa8e.png">

Listing with filtering:

<img width="1359" alt="image" src="https://user-images.githubusercontent.com/1099483/91500807-cfa3bf00-e889-11ea-81c1-586221e45f13.png">


**Merge deadline**: "None" if there's no rush, "ASAP" if it's critical, or provide a specific date if there is one.

**Testing instructions**:

1. Use the `edx-platform` branch `open-craft:library_types` on the backend.
1. Follow the directions in https://github.com/edx/frontend-app-library-authoring/pull/4 up until item 15.
1. Create a new library of each type.
1. Create blocks in the library. In complex and legacy libraries, you should be able to create many different types.
1. In Video and problem libraries, you should be able to only create blocks of their respective type.
1. For complex, video, and problem libraries, test conversion by going to the Details menu for the library and switching the type.
    * This should succeed if the library is empty always.
    * It should succeed if moving from video or problem to complex.
    * It should succeed if moving from complex to problem, or complex to video, when all blocks match their respective types.
    * It should fail if moving from complex to problem, or problem to complex, if all blocks don't match the target type.
1. You should be able to filter the libraries by type on the library listing page. 

**Reviewers**
- [x] @yekibud 
- [x] @kdmccormick 
- [ ] @arbrandes (a11y)