### PR TITLE
[BD-14] SE-2931 user access configuration

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -82,3 +82,6 @@ Known Issues
   libraries but cannot be edited using Studio's authoring view.  This is a
   limitation of Studio, not this MFE.  Work is under way to improve Studio
   accordingly.
+
+* Users with view only access are able to see the 'User Access' menu item, despite
+  the fact it will just kick them back to the detail view.

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -18,6 +18,7 @@ import {
   LibraryPage,
   LibraryListPage,
   StudioHeader,
+  LibraryAccessPage,
 } from './library-authoring';
 import './index.scss';
 import './assets/favicon.ico';
@@ -37,6 +38,7 @@ subscribe(APP_READY, () => {
             <Route exact path={ROUTES.List.HOME} component={LibraryListPage} />
             <Route exact path={ROUTES.Detail.HOME} component={LibraryPage} />
             <Route exact path={ROUTES.Detail.EDIT} component={LibraryEditPage} />
+            <Route exact path={ROUTES.Detail.ACCESS} component={LibraryAccessPage} />
             <Route exact path={ROUTES.Block.HOME} component={LibraryBlockPage} />
             <Route exact path={ROUTES.Block.EDIT} component={LibraryBlockPage} />
             <Route exact path={ROUTES.Block.ASSETS} component={LibraryBlockPage} />

--- a/src/library-authoring/common/data/constants.js
+++ b/src/library-authoring/common/data/constants.js
@@ -16,6 +16,12 @@ export const SUBMISSION_STATUS = {
   FAILED: 'failed',
 };
 
+export const LIBRARY_ACCESS = {
+  ADMIN: 'admin',
+  AUTHOR: 'author',
+  READ: 'read',
+};
+
 export const ROUTES = {
   List: {
     HOME: '/',
@@ -25,6 +31,8 @@ export const ROUTES = {
     HOME_SLUG: (libraryId) => `/library/${libraryId}`,
     EDIT: '/library/:libraryId/edit',
     EDIT_SLUG: (libraryId) => `/library/${libraryId}/edit`,
+    ACCESS: '/library/:libraryId/access',
+    ACCESS_SLUG: (libraryId) => `/library/${libraryId}/access`,
   },
   Block: {
     HOME: '/library/:libraryId/blocks/:blockId',

--- a/src/library-authoring/common/index.scss
+++ b/src/library-authoring/common/index.scss
@@ -29,3 +29,11 @@
     }
   }
 }
+
+.well {
+  border: 1px solid $gray-l3;
+  border-radius: ($baseline/4);
+  box-shadow: 0 1px 3px $shadow inset;
+  background-color: $gray-l5;
+  padding: ($baseline/2);
+}

--- a/src/library-authoring/common/messages.js
+++ b/src/library-authoring/common/messages.js
@@ -11,6 +11,26 @@ const messages = defineMessages({
     defaultMessage: 'Libraries',
     description: 'Text on the libraries tab.',
   },
+  'library.common.forms.button.cancel': {
+    id: 'library.common.forms.cancel',
+    defaultMessage: 'Cancel',
+    description: 'Default label for "Cancel" buttons.',
+  },
+  'library.common.forms.button.submit': {
+    id: 'library.common.forms.button.submit',
+    defaultMessage: 'Submit',
+    description: 'Default label for "Submit" buttons.',
+  },
+  'library.common.forms.button.submitting': {
+    id: 'library.common.forms.button.submitting',
+    defaultMessage: 'Submitting...',
+    description: 'Default label for "Submit" buttons when currently submitting.',
+  },
+  'library.common.forms.button.yes': {
+    id: 'library.common.forms.button.yes',
+    defaultMessage: 'Yes.',
+    description: 'Default label for "Yes" on a confirmation prompt.',
+  },
 });
 
 export default messages;

--- a/src/library-authoring/create-library/LibraryCreateForm.jsx
+++ b/src/library-authoring/create-library/LibraryCreateForm.jsx
@@ -21,6 +21,7 @@ import {
   selectLibraryCreate,
 } from './data';
 
+import commonMessages from '../common/messages';
 import messages from './messages';
 
 class LibraryCreateForm extends React.Component {
@@ -237,9 +238,9 @@ class LibraryCreateForm extends React.Component {
           <StatefulButton
             state={this.getSubmitButtonState()}
             labels={{
-              disabled: intl.formatMessage(messages['library.form.button.submit']),
-              enabled: intl.formatMessage(messages['library.form.button.submit']),
-              pending: intl.formatMessage(messages['library.form.button.submitting']),
+              disabled: intl.formatMessage(commonMessages['library.common.forms.button.submit']),
+              enabled: intl.formatMessage(commonMessages['library.common.forms.button.submit']),
+              pending: intl.formatMessage(commonMessages['library.common.forms.button.submitting']),
             }}
             icons={{
               pending: <Icon className="fa fa-spinner fa-spin" />,
@@ -252,7 +253,7 @@ class LibraryCreateForm extends React.Component {
             className="action btn-light"
             onClick={this.onCancel}
           >
-            {intl.formatMessage(messages['library.form.button.cancel'])}
+            {intl.formatMessage(commonMessages['library.common.forms.button.cancel'])}
           </Button>
         </div>
       </form>

--- a/src/library-authoring/create-library/messages.js
+++ b/src/library-authoring/create-library/messages.js
@@ -68,16 +68,6 @@ const messages = defineMessages({
     defaultMessage: 'The type of library that will be created.',
     description: 'Help text for the type field.',
   },
-  'library.form.button.submit': {
-    id: 'library.form.button.submit',
-    defaultMessage: 'Create',
-    description: 'Text for the submit button.',
-  },
-  'library.form.button.submitting': {
-    id: 'library.form.button.submitting',
-    defaultMessage: 'Creating',
-    description: 'Text for the submit button when submitting.',
-  },
   'library.form.button.cancel': {
     id: 'library.form.button.cancel',
     defaultMessage: 'Cancel',

--- a/src/library-authoring/index.js
+++ b/src/library-authoring/index.js
@@ -5,3 +5,4 @@ export * from './edit-library';
 export * from './library-detail';
 export * from './list-libraries';
 export * from './studio-header';
+export * from './library-access';

--- a/src/library-authoring/index.scss
+++ b/src/library-authoring/index.scss
@@ -3,3 +3,4 @@
 @import './studio-header/index.scss';
 @import './list-libraries/index.scss';
 @import './library-detail/index.scss';
+@import './library-access/index.scss';

--- a/src/library-authoring/library-access/LibraryAccessForm.jsx
+++ b/src/library-authoring/library-access/LibraryAccessForm.jsx
@@ -1,0 +1,194 @@
+/*
+Form for adding a new Library user.
+ */
+import {
+  Button, Card, Icon, Input, Row, StatefulButton, ValidationFormGroup,
+} from '@edx/paragon';
+import React, { useCallback, useState } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { LIBRARY_ACCESS, libraryShape, SUBMISSION_STATUS } from '../common/data';
+import messages from './messages';
+import commonMessages from '../common/messages';
+import {
+  addUser, clearAccessErrors, libraryAccessInitialState, selectLibraryAccess,
+} from './data';
+
+/**
+ * LibraryAccessForm:
+ * Template component for the form used to add a new user to a library.
+ */
+const LibraryAccessForm = (
+  {
+    intl, onSubmit, setShowAdd, hasFieldError, getFieldError, data,
+    onValueChange, submitButtonState,
+  },
+) => (
+  <>
+    <Row className="mb-2">
+      <form className="col-12" onSubmit={onSubmit}>
+        <Card>
+          <Card.Body>
+            <div className="form-create">
+              <Card.Title>{intl.formatMessage(messages['library.access.form.title'])}</Card.Title>
+              <fieldset>
+                <ol className="list-input">
+                  <li className="field">
+                    <ValidationFormGroup
+                      for="title"
+                      helpText={intl.formatMessage(messages['library.access.form.email.help'])}
+                      invalid={hasFieldError('email')}
+                      invalidMessage={getFieldError('email')}
+                      className="mb-0 mr-2"
+                    >
+                      <label className="h6 d-block" htmlFor="email">
+                        {intl.formatMessage(messages['library.access.form.email.label'])}
+                      </label>
+                      <Input
+                        name="email"
+                        id="email"
+                        type="text"
+                        placeholder={intl.formatMessage(messages['library.access.form.email.placeholder'])}
+                        value={data.email}
+                        onChange={onValueChange}
+                      />
+                    </ValidationFormGroup>
+                  </li>
+                </ol>
+              </fieldset>
+            </div>
+          </Card.Body>
+        </Card>
+        <Card className="mb-5">
+          <Card.Body>
+            <StatefulButton
+              variant="primary"
+              type="submit"
+              size="lg"
+              state={submitButtonState}
+              labels={{
+                disabled: intl.formatMessage(commonMessages['library.common.forms.button.submit']),
+                enabled: intl.formatMessage(commonMessages['library.common.forms.button.submit']),
+                pending: intl.formatMessage(commonMessages['library.common.forms.button.submitting']),
+              }}
+              icons={{
+                pending: <Icon className="fa fa-spinner fa-spin" />,
+              }}
+              disabledStates={['disabled', 'pending']}
+              className="font-weight-bold text-uppercase"
+            />
+            <Button size="lg" variant="secondary" className="mx-3 font-weight-bold text-uppercase" onClick={() => setShowAdd(false)}>
+              {intl.formatMessage(commonMessages['library.common.forms.button.cancel'])}
+            </Button>
+          </Card.Body>
+        </Card>
+      </form>
+    </Row>
+  </>
+);
+
+LibraryAccessForm.propTypes = {
+  intl: intlShape.isRequired,
+  data: PropTypes.shape({
+    email: PropTypes.string, access_level: PropTypes.string,
+  }).isRequired,
+  onValueChange: PropTypes.func.isRequired,
+  onSubmit: PropTypes.func.isRequired,
+  setShowAdd: PropTypes.func.isRequired,
+  hasFieldError: PropTypes.func.isRequired,
+  getFieldError: PropTypes.func.isRequired,
+  submitButtonState: PropTypes.string.isRequired,
+};
+
+const initialFormState = () => ({
+  email: '',
+  access_level: LIBRARY_ACCESS.READ,
+});
+
+/**
+ * LibraryAccessFormContainer:
+ * Container for the LibraryAccessForm. This wraps LibraryAccessForm
+ * and handles state for it, and manages the API call for adding a
+ * new user to a library team.
+ */
+const LibraryAccessFormContainer = (
+  props,
+) => {
+  const [data, setData] = useState({
+    email: '',
+    access_level: LIBRARY_ACCESS.READ,
+  });
+
+  const onSubmit = useCallback((event) => {
+    event.preventDefault();
+    props.addUser({ libraryId: props.library.id, data }).then(() => {
+      setData(initialFormState());
+    }).catch(() => undefined);
+  }, [props, data]);
+
+  const onValueChange = useCallback((event) => {
+    const { name, value } = event.target;
+    setData(current => (
+      {
+        ...current,
+        [name]: value,
+      }
+    ));
+  }, [setData]);
+
+  const hasFieldError = (fieldName) => !!(props.errorFields && (fieldName in props.errorFields));
+
+  const getFieldError = (fieldName) => {
+    if (hasFieldError(fieldName)) {
+      return props.errorFields[fieldName];
+    }
+    return null;
+  };
+
+  let submitButtonState;
+  if (props.submissionStatus === SUBMISSION_STATUS.SUBMITTING) {
+    submitButtonState = 'pending';
+  } else if (data.email.match(/.+@.+[.].+/)) {
+    submitButtonState = 'enabled';
+  } else {
+    submitButtonState = 'disabled';
+  }
+
+  return (
+    <LibraryAccessForm
+      intl={props.intl}
+      library={props.library}
+      data={data}
+      submitButtonState={submitButtonState}
+      clearAccessErrors={props.clearAccessErrors}
+      hasFieldError={hasFieldError}
+      getFieldError={getFieldError}
+      onValueChange={onValueChange}
+      onSubmit={onSubmit}
+      setShowAdd={props.setShowAdd}
+    />
+  );
+};
+
+LibraryAccessFormContainer.defaultProps = libraryAccessInitialState;
+
+LibraryAccessFormContainer.propTypes = {
+  intl: intlShape.isRequired,
+  library: libraryShape.isRequired,
+  clearAccessErrors: PropTypes.func.isRequired,
+  addUser: PropTypes.func.isRequired,
+  setShowAdd: PropTypes.func.isRequired,
+  submissionStatus: PropTypes.oneOf(Object.values(SUBMISSION_STATUS)).isRequired,
+  errorFields: PropTypes.shape({
+    email: PropTypes.string,
+  }),
+};
+
+export default connect(
+  selectLibraryAccess,
+  {
+    clearAccessErrors,
+    addUser,
+  },
+)(injectIntl(LibraryAccessFormContainer));

--- a/src/library-authoring/library-access/LibraryAccessPage.jsx
+++ b/src/library-authoring/library-access/LibraryAccessPage.jsx
@@ -1,0 +1,269 @@
+/*
+Library Access Page. This component handles team permissions access.
+ */
+import React, { useContext, useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { connect } from 'react-redux';
+import { withRouter } from 'react-router';
+import {
+  Alert, Button, Col, Row,
+} from '@edx/paragon';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faPlus } from '@fortawesome/free-solid-svg-icons';
+import { AppContext } from '@edx/frontend-platform/react';
+import messages from './messages';
+import { LoadingPage } from '../../generic';
+import { fetchLibraryDetail } from '../library-detail/data';
+import LibraryAccessFormContainer from './LibraryAccessForm';
+import {
+  LIBRARY_ACCESS, libraryShape, LOADING_STATUS, ROUTES, truncateErrorMessage,
+} from '../common/data';
+import {
+  addUser,
+  clearAccess,
+  clearAccessErrors,
+  fetchUserList,
+  libraryAccessInitialState,
+  libraryUserShape,
+  selectLibraryAccess,
+} from './data';
+// eslint-disable-next-line import/no-named-as-default
+import UserAccessContainer from './UserAccessContainer';
+
+
+/**
+ * LibraryAccessPage:
+ * Template component for the access management page for libraries.
+ */
+const LibraryAccessPage = ({
+  intl, library, users, setShowAdd, errorMessage, showAdd, handleDismissAlert, multipleAdmins, isAdmin,
+}) => (
+  <div className="library-access-wrapper">
+    <div className="wrapper-mast wrapper">
+      <header className="mast has-actions has-navigation has-subtitle">
+        <div className="page-header">
+          <small className="subtitle">{intl.formatMessage(messages['library.access.page.parent_heading'])}</small>
+          <h1 className="page-header-title">{intl.formatMessage(messages['library.access.page.heading'])}</h1>
+        </div>
+        <nav className="nav-actions">
+          <ul>
+            {isAdmin && (
+              <li className="nav-item">
+                <Button
+                  variant="success"
+                  onClick={() => setShowAdd(true)}
+                >
+                  <FontAwesomeIcon icon={faPlus} className="pr-3 icon-inline" />
+                  {intl.formatMessage(messages['library.access.new.user'])}
+                </Button>
+              </li>
+            )}
+          </ul>
+        </nav>
+      </header>
+    </div>
+    <div className="wrapper-content wrapper">
+      <section className="content">
+        <article className="content-primary" role="main">
+          {errorMessage
+          && (
+            <Alert
+              variant="danger"
+              onClose={() => handleDismissAlert()}
+              dismissible
+            >
+              {truncateErrorMessage(errorMessage)}
+            </Alert>
+          )}
+          {showAdd
+          && (
+            <LibraryAccessFormContainer
+              setShowAdd={(value) => setShowAdd(value)}
+              library={library}
+            />
+          )}
+          <Row>
+            { ((users && users.map((user) => (
+              (
+                <UserAccessContainer
+                  intl={intl}
+                  user={user}
+                  key={user.username}
+                  multipleAdmins={multipleAdmins}
+                  library={library}
+                  isAdmin={isAdmin}
+                />
+              ))))
+              || (
+                <Col cols={12} className="text-center">
+                  <LoadingPage loadingMessage={intl.formatMessage(messages['library.access.loading.message'])} />
+                </Col>
+              )
+            )}
+          </Row>
+          {isAdmin && (
+            <div className="well mt-3">
+              <Row className="h-100">
+                <Col xs={12} md={8} className="my-auto">
+                  <h2 className="h2 font-weight-bold">{intl.formatMessage(messages['library.access.well.title'])}</h2>
+                  <p>{intl.formatMessage(messages['library.access.well.text'])}</p>
+                </Col>
+                <Col xs={12} md={4} lg={3} className="my-auto offset-lg-1 text-center text-md-right">
+                  <Button variant="success" size="lg" onClick={() => setShowAdd(true)}>
+                    <FontAwesomeIcon icon={faPlus} className="pr-1 icon-inline" />
+                    <strong>{intl.formatMessage(messages['library.access.well.button'])}</strong>
+                  </Button>
+                </Col>
+              </Row>
+            </div>
+          )}
+        </article>
+        <aside className="content-supplementary">
+          <div className="bit">
+            <h3 className="title title-3">{intl.formatMessage(messages['library.access.aside.title'])}</h3>
+            <p>{intl.formatMessage(messages['library.access.aside.text.first'])}</p>
+            <p>{intl.formatMessage(messages['library.access.aside.text.second'])}</p>
+            <p>{intl.formatMessage(messages['library.access.aside.text.third'])}</p>
+            <p>{intl.formatMessage(messages['library.access.aside.text.fourth'])}</p>
+
+          </div>
+        </aside>
+      </section>
+    </div>
+  </div>
+);
+
+LibraryAccessPage.defaultProps = { ...libraryAccessInitialState };
+
+LibraryAccessPage.propTypes = {
+  intl: intlShape.isRequired,
+  library: libraryShape,
+  users: PropTypes.arrayOf(libraryUserShape),
+  setShowAdd: PropTypes.func.isRequired,
+  errorMessage: PropTypes.string,
+  showAdd: PropTypes.bool.isRequired,
+  handleDismissAlert: PropTypes.func.isRequired,
+  multipleAdmins: PropTypes.bool.isRequired,
+  isAdmin: PropTypes.bool.isRequired,
+};
+
+/**
+ * LibraryAccessPageContainer:
+ * Widget for editing the list of users with access to this content library.
+ * This wraps LibraryAccessPage and handles API calls to fetch/write data, as well as displaying
+ * a loading message during initial loading. This separation allows LibraryAccessPage to be tested
+ * in unit tests without needing to mock the API.
+ */
+const LibraryAccessPageContainer = ({
+  intl, users, errorMessage, ...props
+}) => {
+  const [showAdd, setShowAdd] = useState(false);
+  const multipleAdmins = !!(users && users.filter((user) => user.access_level === 'admin').length >= 2);
+  const { authenticatedUser } = useContext(AppContext);
+  let libraryAdmin = (users && users.filter((user) => (
+    (user.username === authenticatedUser.username)
+    && (user.access_level === LIBRARY_ACCESS.ADMIN)
+  )));
+  // This array is special somehow and despite being empty will eval as true.
+  libraryAdmin = !!(libraryAdmin || []).length;
+  const isAdmin = !!(authenticatedUser.administrator || libraryAdmin);
+
+  // Explicit empty dependencies means on mount.
+  useEffect(() => {
+    const { libraryId } = props.match.params;
+    if (props.library === null) {
+      props.fetchLibraryDetail({ libraryId });
+    }
+    if (users === null) {
+      props.fetchUserList({ libraryId });
+    }
+  }, []);
+  // Returning a function with an empty dependencies list indicates this is to be done on unmount,
+  // rather than on data change.
+  useEffect(() => () => {
+    props.clearAccess();
+  }, []);
+
+  useEffect(() => {
+    // To be done on each data reload. If the user's list doesn't contain the user, or if the user now no longer has
+    // staff privs, we need to send the user back to the libraries index.
+    if (users === null) {
+      // Still loading. Ignore.
+      return;
+    }
+    const admin = users.filter((user) => user.username === authenticatedUser.username)[0];
+    if ((admin === undefined) || admin.access_level === LIBRARY_ACCESS.READ) {
+      props.history.replace(ROUTES.List.HOME);
+    }
+  });
+
+  const handleDismissAlert = () => {
+    props.clearAccessErrors();
+  };
+
+  const renderLoading = () => (
+    <LoadingPage loadingMessage={intl.formatMessage(messages['library.access.loading.message'])} />
+  );
+
+  const renderContent = () => (
+    <LibraryAccessPage
+      setShowAdd={setShowAdd}
+      errorMessage={errorMessage}
+      handleDismissAlert={handleDismissAlert}
+      intl={intl}
+      showAdd={showAdd}
+      users={users}
+      multipleAdmins={multipleAdmins}
+      isAdmin={isAdmin}
+    />
+  );
+
+  let content;
+  if (props.loadingStatus === LOADING_STATUS.LOADING) {
+    content = renderLoading();
+  } else {
+    content = renderContent();
+  }
+
+  return (
+    <div className="container-fluid">
+      {content}
+    </div>
+  );
+};
+
+
+LibraryAccessPageContainer.propTypes = {
+  // errorMessage: PropTypes.string,
+  intl: intlShape.isRequired,
+  library: libraryShape,
+  errorMessage: PropTypes.string,
+  fetchLibraryDetail: PropTypes.func.isRequired,
+  fetchUserList: PropTypes.func.isRequired,
+  clearAccess: PropTypes.func.isRequired,
+  clearAccessErrors: PropTypes.func.isRequired,
+  loadingStatus: PropTypes.oneOf(Object.values(LOADING_STATUS)).isRequired,
+  users: PropTypes.arrayOf(libraryUserShape),
+  match: PropTypes.shape({
+    params: PropTypes.shape({
+      libraryId: PropTypes.string.isRequired,
+    }).isRequired,
+  }).isRequired,
+  history: PropTypes.shape({
+    replace: PropTypes.func.isRequired,
+  }).isRequired,
+};
+
+LibraryAccessPageContainer.defaultProps = { ...libraryAccessInitialState };
+
+export default connect(
+  selectLibraryAccess,
+  {
+    addUser,
+    clearAccessErrors,
+    clearAccess,
+    fetchLibraryDetail,
+    fetchUserList,
+  },
+)(injectIntl(withRouter(LibraryAccessPageContainer)));

--- a/src/library-authoring/library-access/UserAccessContainer.jsx
+++ b/src/library-authoring/library-access/UserAccessContainer.jsx
@@ -1,0 +1,188 @@
+/*
+Component for displaying and modifying a user's access level for a library.
+ */
+import {
+  Badge,
+  Button, Card, Col, Modal, Row,
+} from '@edx/paragon';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faTrash } from '@fortawesome/free-solid-svg-icons';
+import React, { useContext, useState } from 'react';
+import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { AppContext } from '@edx/frontend-platform/react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+import {
+  libraryUserShape, removeUserAccess, selectLibraryAccess, setUserAccess,
+} from './data';
+import { LIBRARY_ACCESS, libraryShape } from '../common/data';
+import commonMessages from '../common/messages';
+import messages from './messages';
+
+export const UserAccessContainer = ({
+  intl, library, user, multipleAdmins, setAccessLevel, removeAccess, isUser, showRemoveModal, setShowRemoveModal,
+  showDeprivModal, setShowDeprivModal, isAdmin, adminLocked,
+}) => (
+  <Col xs={12} className="py-3">
+    <Card>
+      <Card.Body>
+        <Badge className={`position-absolute ml-1 permy ${user.access_level}`}>
+          <strong>{intl.formatMessage(messages[`library.access.info.${user.access_level}`])}</strong>&nbsp;
+          <span className="font-weight-normal">{isUser && intl.formatMessage(messages['library.access.info.self'])}</span>
+        </Badge>
+        <Row className="py-3">
+          <Col xs={12} md={6}>
+            <span className="title title-2">
+              <span className="font-weight-bold">{user.username}</span>
+            </span>
+            <span className="title px-2">
+              <a href={`mailto:${user.email}`}>{user.email}</a>
+            </span>
+          </Col>
+          {isAdmin && (
+          <Col xs={12} md={6}>
+            <Row>
+              {(user.access_level === LIBRARY_ACCESS.ADMIN) && adminLocked && (
+              <Col xs={12} className="text-center text-md-right">
+                <small>{intl.formatMessage(messages['library.access.info.admin_unlock'])}</small>
+              </Col>
+              )}
+              {user.access_level === LIBRARY_ACCESS.ADMIN && multipleAdmins && (
+              <Col xs={10} className="text-left text-md-right">
+                <Button size="lg" variant="secondary" onClick={() => setShowDeprivModal(true)}>
+                  {intl.formatMessage(messages['library.access.user.remove_admin'])}
+                </Button>
+                <Modal
+                  open={showDeprivModal}
+                  title={intl.formatMessage(messages['library.access.modal.remove_admin.title'])}
+                  onClose={() => setShowDeprivModal(false)}
+                  body={(
+                    <div>
+                      <p>
+                        {intl.formatMessage(
+                          messages['library.access.modal.remove_admin.body'],
+                          { library: library.title, email: user.email },
+                        )}
+                      </p>
+                    </div>
+                  )}
+                  buttons={[
+                    <Button
+                      onClick={() => setAccessLevel(LIBRARY_ACCESS.AUTHOR).then(setShowDeprivModal(false))}
+                    >
+                      {intl.formatMessage(commonMessages['library.common.forms.button.yes'])}
+                    </Button>,
+                  ]}
+                />
+              </Col>
+              )}
+              {user.access_level === LIBRARY_ACCESS.READ && (
+              <Col xs={10} className="text-left text-md-right">
+                <Button size="lg" variant="primary" onClick={() => setAccessLevel(LIBRARY_ACCESS.AUTHOR)}>
+                  {intl.formatMessage(messages['library.access.user.add_author'])}
+                </Button>
+              </Col>
+              )}
+              {user.access_level === LIBRARY_ACCESS.AUTHOR && (
+                <>
+                  <Col xs={5} className="text-left text-md-right pl-md-1">
+                    <Button size="lg" variant="secondary" onClick={() => setAccessLevel(LIBRARY_ACCESS.READ)}>
+                      {intl.formatMessage(messages['library.access.user.remove_author'])}
+                    </Button>
+                  </Col>
+                  <Col xs={5} className="text-left text-md-right pl-md-1">
+                    <Button size="lg" variant="primary" onClick={() => setAccessLevel(LIBRARY_ACCESS.ADMIN)}>
+                      {intl.formatMessage(messages['library.access.user.add_admin'])}
+                    </Button>
+                  </Col>
+                </>
+              )}
+              {(!((user.access_level === LIBRARY_ACCESS.ADMIN) && adminLocked)) && (
+              <Col xs={2} className="text-right text-md-center">
+                <Button size="lg" variant="danger" onClick={() => setShowRemoveModal(true)}>
+                  <span className="sr-only">{intl.formatMessage(messages['library.access.user.remove_user'])}</span>
+                  <FontAwesomeIcon icon={faTrash} />
+                </Button>
+                <Modal
+                  open={showRemoveModal}
+                  title={intl.formatMessage(messages['library.access.modal.remove.title'])}
+                  onClose={() => setShowRemoveModal(false)}
+                  body={(
+                    <div>
+                      <p>
+                        {intl.formatMessage(
+                          messages['library.access.modal.remove.body'],
+                          { library: library.title, email: user.email },
+                        )}
+                      </p>
+                    </div>
+                    )}
+                  buttons={[
+                    <Button onClick={() => removeAccess()}>
+                      {intl.formatMessage(commonMessages['library.common.forms.button.yes'])}
+                    </Button>,
+                  ]}
+                />
+              </Col>
+              )}
+            </Row>
+          </Col>
+          )}
+        </Row>
+      </Card.Body>
+    </Card>
+  </Col>
+);
+export const UserAccessContainerBase = injectIntl(({
+  user, ...props
+}) => {
+  const { authenticatedUser } = useContext(AppContext);
+  const isUser = authenticatedUser.username === user.username;
+  const [showRemoveModal, setShowRemoveModal] = useState(false);
+  const [showDeprivModal, setShowDeprivModal] = useState(false);
+  const adminLocked = user.access_level === LIBRARY_ACCESS.ADMIN && !props.multipleAdmins;
+
+  const setAccessLevel = (level) => props.setUserAccess({ libraryId: props.library.id, user, level });
+
+  const removeAccess = () => props.removeUserAccess({ libraryId: props.library.id, user });
+
+  const newProps = {
+    ...props,
+    showRemoveModal,
+    setShowRemoveModal,
+    showDeprivModal,
+    setShowDeprivModal,
+    isUser,
+    user,
+    adminLocked,
+    setAccessLevel,
+    removeAccess,
+  };
+  return <UserAccessContainer {...newProps} />;
+});
+
+UserAccessContainerBase.propTypes = {
+  user: libraryUserShape.isRequired,
+  intl: intlShape.isRequired,
+  library: libraryShape.isRequired,
+  multipleAdmins: PropTypes.bool.isRequired,
+  setUserAccess: PropTypes.func.isRequired,
+  removeUserAccess: PropTypes.func.isRequired,
+};
+
+UserAccessContainer.propTypes = {
+  ...UserAccessContainerBase.propTypes,
+  isUser: PropTypes.bool.isRequired,
+  showRemoveModal: PropTypes.bool.isRequired,
+  setShowRemoveModal: PropTypes.func.isRequired,
+  showDeprivModal: PropTypes.bool.isRequired,
+  setShowDeprivModal: PropTypes.func.isRequired,
+};
+
+export default connect(
+  selectLibraryAccess,
+  {
+    setUserAccess,
+    removeUserAccess,
+  },
+)(injectIntl(UserAccessContainerBase));

--- a/src/library-authoring/library-access/data/api.js
+++ b/src/library-authoring/library-access/data/api.js
@@ -1,0 +1,68 @@
+import { ensureConfig, getConfig } from '@edx/frontend-platform';
+import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+
+ensureConfig([
+  'STUDIO_BASE_URL',
+], 'Library API service');
+
+function setupRequest() {
+  return { client: getAuthenticatedHttpClient(), baseUrl: getConfig().STUDIO_BASE_URL };
+}
+
+/* eslint-disable-next-line import/prefer-default-export */
+export async function fetchUsers(libraryId) {
+  const { client, baseUrl } = setupRequest();
+  const response = await client.get(
+    `${baseUrl}/api/libraries/v2/${libraryId}/team/`,
+  ).catch((error) => {
+    /* Normalize error data. */
+    const apiError = Object.create(error);
+    apiError.message = null;
+    apiError.fields = JSON.parse(error.customAttributes.httpErrorResponseData);
+    throw apiError;
+  });
+  return response.data;
+}
+
+export async function addUserToLibrary({ libraryId, data }) {
+  const { client, baseUrl } = setupRequest();
+  const response = await client.post(
+    `${baseUrl}/api/libraries/v2/${libraryId}/team/`,
+    data,
+  ).catch((error) => {
+    /* Normalize error data. */
+    const apiError = Object.create(error);
+    apiError.message = null;
+    apiError.fields = JSON.parse(error.customAttributes.httpErrorResponseData);
+    throw apiError;
+  });
+  return response.data;
+}
+
+export async function setUserAccessLevel({ libraryId, user, level }) {
+  const { client, baseUrl } = setupRequest();
+  const response = await client.put(
+    `${baseUrl}/api/libraries/v2/${libraryId}/team/user/${user.username}/`,
+    { access_level: level },
+  ).catch((error) => {
+    /* Normalize error data. */
+    const apiError = Object.create(error);
+    apiError.message = null;
+    apiError.fields = JSON.parse(error.customAttributes.httpErrorResponseData);
+    throw apiError;
+  });
+  return response.data;
+}
+
+export async function removeUserFromLibrary({ libraryId, user }) {
+  const { client, baseUrl } = setupRequest();
+  return client.delete(
+    `${baseUrl}/api/libraries/v2/${libraryId}/team/user/${user.username}/`,
+  ).catch((error) => {
+    /* Normalize error data. */
+    const apiError = Object.create(error);
+    apiError.message = null;
+    apiError.fields = JSON.parse(error.customAttributes.httpErrorResponseData);
+    throw apiError;
+  });
+}

--- a/src/library-authoring/library-access/data/index.js
+++ b/src/library-authoring/library-access/data/index.js
@@ -1,0 +1,4 @@
+export { default as selectLibraryAccess } from './selectors';
+export * from './slice';
+export * from './thunks';
+export * from './shapes';

--- a/src/library-authoring/library-access/data/selectors.js
+++ b/src/library-authoring/library-access/data/selectors.js
@@ -1,0 +1,17 @@
+import { createSelector } from 'reselect';
+import { libraryAccessStoreName as storeName } from './slice';
+import { selectLibraryDetail } from '../../library-detail/data';
+
+const stateSelector = state => ({ ...state[storeName] });
+
+const selectLibraryAccess = createSelector(
+  stateSelector,
+  selectLibraryDetail,
+  (editState, libraryState) => ({
+    ...editState,
+    library: libraryState.library,
+    loadingStatus: libraryState.status,
+  }),
+);
+
+export default selectLibraryAccess;

--- a/src/library-authoring/library-access/data/shapes.js
+++ b/src/library-authoring/library-access/data/shapes.js
@@ -1,0 +1,9 @@
+import PropTypes from 'prop-types';
+import { LIBRARY_ACCESS } from '../../common/data';
+
+// eslint-disable-next-line import/prefer-default-export
+export const libraryUserShape = PropTypes.shape({
+  username: PropTypes.string.isRequired,
+  email: PropTypes.string.isRequired,
+  access_level: PropTypes.oneOf([...Object.values(LIBRARY_ACCESS)]),
+});

--- a/src/library-authoring/library-access/data/slice.js
+++ b/src/library-authoring/library-access/data/slice.js
@@ -1,0 +1,58 @@
+/* eslint-disable no-param-reassign */
+import { createSlice } from '@reduxjs/toolkit';
+
+import { LOADING_STATUS, SUBMISSION_STATUS } from '../../common';
+
+export const libraryAccessStoreName = 'libraryAccess';
+
+export const libraryAccessInitialState = {
+  library: null,
+  users: null,
+  errorMessage: null,
+  errorFields: null,
+  loadingStatus: LOADING_STATUS.LOADING,
+  submissionStatus: SUBMISSION_STATUS.UNSUBMITTED,
+};
+
+const slice = createSlice({
+  name: libraryAccessStoreName,
+  initialState: libraryAccessInitialState,
+  reducers: {
+    libraryAccessRequest: (state) => {
+      state.status = LOADING_STATUS.LOADING;
+    },
+    libraryAccessFailed: (state, { payload }) => {
+      state.errorMessage = payload.errorMessage;
+      state.errorFields = payload.errorFields;
+      state.status = SUBMISSION_STATUS.FAILED;
+    },
+    libraryAccessClearError: (state) => {
+      state.errorMessage = null;
+      state.errorFields = null;
+    },
+    libraryAccessReset: (state) => {
+      state.errorMessage = libraryAccessInitialState.errorMessage;
+      state.errorFields = libraryAccessInitialState.errorFields;
+      state.status = libraryAccessInitialState.status;
+    },
+    libraryAddUser: (state, { payload }) => {
+      state.users.unshift(payload.user);
+    },
+    libraryRemoveUser: (state, { payload }) => {
+      state.users = state.users.filter((user) => user.username !== payload.user.username);
+    },
+    libraryUpdateUser: (state, { payload }) => {
+      const existing = state.users.filter((user) => user.username === payload.user.username)[0];
+      Object.assign(existing, payload.user);
+    },
+    libraryUsersSuccess: (state, { payload }) => {
+      state.users = payload.users;
+    },
+    libraryAccessClear: (state) => {
+      Object.assign(state, { ...libraryAccessInitialState });
+    },
+  },
+});
+
+export const libraryAccessActions = slice.actions;
+export const libraryAccessReducer = slice.reducer;

--- a/src/library-authoring/library-access/data/thunks.js
+++ b/src/library-authoring/library-access/data/thunks.js
@@ -1,0 +1,58 @@
+import { logError } from '@edx/frontend-platform/logging';
+import { libraryAccessActions as actions } from './slice';
+import * as api from './api';
+
+/* eslint-disable-next-line import/prefer-default-export */
+export const fetchUserList = ({ libraryId }) => async (dispatch) => {
+  try {
+    const users = await api.fetchUsers(libraryId);
+    dispatch(actions.libraryUsersSuccess({ users }));
+  } catch (error) {
+    dispatch(actions.libraryAccessFailed({ errorMessage: error.message }));
+    logError(error);
+  }
+};
+
+export const addUser = ({ libraryId, data }) => async (dispatch) => {
+  try {
+    dispatch(actions.libraryAccessRequest());
+    const newUser = await api.addUserToLibrary({ libraryId, data });
+    dispatch(actions.libraryAddUser({ user: newUser }));
+    dispatch(actions.libraryAccessClearError());
+  } catch (error) {
+    dispatch(actions.libraryAccessFailed({ errorMessage: error.message, errorFields: error.fields }));
+    logError(error);
+    // Don't want to return this as successful, as the form will clear out info if we do.
+    throw error;
+  }
+};
+
+export const setUserAccess = ({ libraryId, user, level }) => async (dispatch) => {
+  try {
+    dispatch(actions.libraryAccessRequest());
+    const updatedUser = await api.setUserAccessLevel({ libraryId, user, level });
+    dispatch(actions.libraryUpdateUser({ user: updatedUser }));
+  } catch (error) {
+    dispatch(actions.libraryAccessFailed({ errorMessage: error.message, errorFields: error.fields }));
+    logError(error);
+  }
+};
+
+export const removeUserAccess = ({ libraryId, user }) => async (dispatch) => {
+  try {
+    dispatch(actions.libraryAccessRequest());
+    await api.removeUserFromLibrary({ libraryId, user });
+    dispatch(actions.libraryRemoveUser({ user }));
+  } catch (error) {
+    dispatch(actions.libraryAccessFailed({ errorMessage: error.message }));
+    logError(error);
+  }
+};
+
+export const clearAccessErrors = () => async (dispatch) => {
+  dispatch(actions.libraryAccessClearError());
+};
+
+export const clearAccess = () => async (dispatch) => {
+  dispatch(actions.libraryAccessClear());
+};

--- a/src/library-authoring/library-access/index.js
+++ b/src/library-authoring/library-access/index.js
@@ -1,0 +1,2 @@
+export { default as LibraryAccessPage } from './LibraryAccessPage'; // eslint-disable-line import/prefer-default-export
+export * from './data';

--- a/src/library-authoring/library-access/index.scss
+++ b/src/library-authoring/library-access/index.scss
@@ -1,0 +1,43 @@
+.perm-badge {
+  position: absolute;
+  top: -1.25rem;
+  margin-left: .5rem;
+  padding: .25rem .75rem .25rem .75rem;
+  color: white;
+  font-size: 70%;
+  text-transform: uppercase;
+  &.admin {
+    background-color: $pink;
+  }
+  &.author {
+    background-color: $blue;
+  }
+  &.read {
+    background-color: $yellow-d1;
+  }
+}
+
+.permy {
+  top: -1rem;
+  color: $white;
+  &.admin {
+    background-color: $pink;
+  }
+  &.author {
+    background-color: $blue;
+  }
+  &.read {
+    background-color: $yellow-d1;
+  }
+}
+
+.card-title {
+  font-size: 150%;
+}
+
+.library-access-wrapper .form-create {
+  border: none;
+  &:hover {
+    box-shadow: none;
+  }
+}

--- a/src/library-authoring/library-access/messages.js
+++ b/src/library-authoring/library-access/messages.js
@@ -1,0 +1,170 @@
+import { defineMessages } from '@edx/frontend-platform/i18n';
+
+const messages = defineMessages({
+  'library.access.loading.message': {
+    id: 'library.access.loading.message',
+    defaultMessage: 'Loading...',
+    description: 'Message when data is being loaded',
+  },
+  'library.access.page.parent_heading': {
+    id: 'library.access.page.parent_heading',
+    defaultMessage: 'Settings',
+    description: 'Small text heading above the main title for the access page',
+  },
+  'library.access.page.heading': {
+    id: 'library.access.page.heading',
+    defaultMessage: 'User Access',
+    description: 'Title of user access settings page',
+  },
+  'library.access.aside.title': {
+    id: 'library.access.aside.title',
+    defaultMessage: 'Library Access Roles',
+    description: 'Header for the aside description of the access page.',
+  },
+  'library.access.aside.text.first': {
+    id: 'library.access.aside.text.first',
+    defaultMessage: 'There are three access roles for libraries: User, Staff, and Admin.',
+    description: 'The first paragraph of detail text on user access roles.',
+  },
+  'library.access.aside.text.second': {
+    id: 'library.access.aside.text.second',
+    defaultMessage: 'Library Users can view library content and can reference or use library components in their '
+      + 'courses, but they cannot edit the contents of a library.',
+    description: 'The second paragraph of detail text on user access roles.',
+  },
+  'library.access.aside.text.third': {
+    id: 'library.access.aside.text.third',
+    defaultMessage: 'Library Staff are content co-authors. They have full editing privileges on the contents '
+      + 'of a library.',
+    description: 'The third paragraph of detail text on user access roles.',
+  },
+  'library.access.aside.text.fourth': {
+    id: 'library.access.aside.text.fourth',
+    defaultMessage: 'Library Admins have full editing privileges and can also add and remove other team members. '
+      + 'There must be at least one user with the Admin role in a library.',
+    description: 'The fourth paragraph of detail text on user access roles.',
+  },
+  'library.access.new.user': {
+    id: 'library.access.new.user',
+    defaultMessage: 'New Team Member',
+    description: 'Button text for adding a new user to the library access roles.',
+  },
+  'library.access.well.title': {
+    id: 'library.access.well.title',
+    defaultMessage: 'Add More Users to This Library',
+    description: 'Title for the "call to action" well on the bottom of the page.',
+  },
+  'library.access.well.text': {
+    id: 'library.access.well.text',
+    defaultMessage: 'Grant other members of your course team access to this library. New library users must have an '
+      + 'active Studio account.',
+    description: 'Text for the "call to action" well on the bottom of the page.',
+  },
+  'library.access.well.button': {
+    id: 'library.access.well.button',
+    defaultMessage: 'Add a New User',
+    description: 'Text for the button in the "call to action" well on the bottom of the page.',
+  },
+  'library.access.form.title': {
+    id: 'library.access.form.title',
+    defaultMessage: 'Grant Access to this Library',
+    description: 'Help text for the email field.',
+  },
+  'library.access.form.email.help': {
+    id: 'library.access.form.email.help',
+    defaultMessage: 'Provide the email address of the user you want to add',
+    description: 'Help text for the email field.',
+  },
+  'library.access.form.email.label': {
+    id: 'library.access.form.email.label',
+    defaultMessage: 'Email',
+    description: 'Label for the email field.',
+  },
+  'library.access.form.email.placeholder': {
+    id: 'library.access.form.email.placeholder',
+    defaultMessage: 'example: username@domain.com',
+    description: 'Placeholder text for the email field.',
+  },
+  'library.access.form.button.submit': {
+    id: 'library.access.form.button.submit',
+    defaultMessage: 'Submit',
+    description: 'Submit button text',
+  },
+  'library.access.form.button.submitting': {
+    id: 'library.access.form.button.submitting',
+    defaultMessage: 'Submitting...',
+    description: 'Submit button text when currently submitting',
+  },
+  'library.access.info.admin_unlock': {
+    id: 'library.access.info.admin_unlock',
+    defaultMessage: 'Promote another member to Admin to remove this user\'s admin rights',
+    description: 'Instructions given for removing your own admin privileges.',
+  },
+  'library.access.info.self': {
+    id: 'library.access.info.self',
+    defaultMessage: 'You!',
+    description: 'Short indicator that the user being viewed is the viewer.',
+  },
+  'library.access.info.admin': {
+    id: 'library.access.info.admin',
+    defaultMessage: 'Admin',
+    description: 'Label for the admin access level.',
+  },
+  'library.access.info.author': {
+    id: 'library.access.info.author',
+    defaultMessage: 'Author',
+    description: 'Label for the author access level.',
+  },
+  'library.access.info.read': {
+    id: 'library.access.info.read',
+    defaultMessage: 'Read Only',
+    description: 'Label for the read only access level.',
+  },
+  'library.access.user.add_admin': {
+    id: 'library.access.user.add_admin',
+    defaultMessage: 'Add Admin Access',
+    description: 'Label for button that grants a user admin access.',
+  },
+  'library.access.user.remove_admin': {
+    id: 'library.access.user.remove_admin',
+    defaultMessage: 'Remove Admin Access',
+    description: 'Label for button that removes a user\'s admin access.',
+  },
+  'library.access.user.add_author': {
+    id: 'library.access.user.add_author',
+    defaultMessage: 'Add Author Access',
+    description: 'Label for button that grants a user author access.',
+  },
+  'library.access.user.remove_author': {
+    id: 'library.access.user.remove_author',
+    defaultMessage: 'Remove Author Access',
+    description: 'Label for button that removes a user\'s author access level.',
+  },
+  'library.access.user.remove_user': {
+    id: 'library.access.user.remove_user',
+    defaultMessage: 'Remove user',
+    description: 'Label for button that removes a user from a library entirely. Screen-reader only.',
+  },
+  'library.access.modal.remove.title': {
+    id: 'library.access.modal.remove.title',
+    defaultMessage: 'Are you sure?',
+    description: 'Title for user removal confirmation modal',
+  },
+  'library.access.modal.remove.body': {
+    id: 'library.access.modal.remove.body',
+    defaultMessage: 'Are you sure you want to delete {email} from the library "{library}"?',
+    description: 'Body of user removal confirmation modal.',
+  },
+  'library.access.modal.remove_admin.title': {
+    id: 'library.access.modal.remove_admin.title',
+    defaultMessage: 'Are you sure?',
+    description: 'Title for user admin privilege removal confirmation modal',
+  },
+  'library.access.modal.remove_admin.body': {
+    id: 'library.access.modal.remove_admin.body',
+    defaultMessage: 'Are you sure you want to revoke admin privileges for {email} from the library "{library}"?',
+    description: 'Body of user admin privilege removal confirmation modal.',
+  },
+});
+
+export default messages;

--- a/src/library-authoring/studio-header/StudioHeader.jsx
+++ b/src/library-authoring/studio-header/StudioHeader.jsx
@@ -50,6 +50,7 @@ const StudioHeader = ({ intl, library }) => {
                     </Dropdown.Toggle>
                     <Dropdown.Menu className="p-4 mt-1 fade">
                       <Dropdown.Item className="p-0" as={Link} to={ROUTES.Detail.EDIT_SLUG(library.id)}>{intl.formatMessage(messages['library.header.settings.details'])}</Dropdown.Item>
+                      <Dropdown.Item className="p-0" as={Link} to={ROUTES.Detail.ACCESS_SLUG(library.id)}>{intl.formatMessage(messages['library.header.settings.access'])}</Dropdown.Item>
                     </Dropdown.Menu>
                   </Dropdown>
                 </nav>

--- a/src/library-authoring/studio-header/messages.js
+++ b/src/library-authoring/studio-header/messages.js
@@ -16,6 +16,11 @@ const messages = defineMessages({
     defaultMessage: 'Details',
     description: 'Text for the details item in the settings menu.',
   },
+  'library.header.settings.access': {
+    id: 'library.header.settings.access',
+    defaultMessage: 'User Access',
+    description: 'Text for the user access permissions item in the settings menu.',
+  },
   'library.header.nav.help.title': {
     id: 'library.header.nav.help.title',
     defaultMessage: 'Online Help',

--- a/src/store.js
+++ b/src/store.js
@@ -10,6 +10,8 @@ import {
   libraryCreateStoreName,
   libraryListReducer,
   libraryListStoreName,
+  libraryAccessStoreName,
+  libraryAccessReducer,
 } from './library-authoring';
 
 const store = configureStore({
@@ -19,6 +21,7 @@ const store = configureStore({
     [libraryEditStoreName]: libraryEditReducer,
     [libraryCreateStoreName]: libraryCreateReducer,
     [libraryListStoreName]: libraryListReducer,
+    [libraryAccessStoreName]: libraryAccessReducer,
   },
 });
 

--- a/src/vendor/studio.scss
+++ b/src/vendor/studio.scss
@@ -319,6 +319,22 @@ $tmg-f3: 0.125s;
 $f-sans-serif: 'Open Sans','Helvetica Neue', Helvetica, Arial, sans-serif;
 $white: rgb(255, 255, 255) !default;
 $white-t3: rgba($white, 0.75) !default;
+$yellow: rgb(237, 189, 60) !default;
+$yellow-l1: tint($yellow, 20%) !default;
+$yellow-l2: tint($yellow, 40%) !default;
+$yellow-l3: tint($yellow, 60%) !default;
+$yellow-l4: tint($yellow, 80%) !default;
+$yellow-l5: tint($yellow, 90%) !default;
+$yellow-d1: shade($yellow, 20%) !default;
+$yellow-d2: shade($yellow, 40%) !default;
+$yellow-d3: shade($yellow, 60%) !default;
+$yellow-d4: shade($yellow, 80%) !default;
+$yellow-s1: saturate($yellow, 15%) !default;
+$yellow-s2: saturate($yellow, 30%) !default;
+$yellow-s3: saturate($yellow, 45%) !default;
+$yellow-u1: desaturate($yellow, 15%) !default;
+$yellow-u2: desaturate($yellow, 30%) !default;
+$yellow-u3: desaturate($yellow, 45%) !default;
 
 // Imported from:
 // edx-platform/common/cms/static/sass/bootstrap/_mixins.scss


### PR DESCRIPTION
This PR adds the ability to manage user permissions for librariesv2. It is dependent on https://github.com/edx/frontend-app-library-authoring/pull/7 For reviewing convenience, a version of this PR that only contains the relevant changes is available here: https://github.com/open-craft/frontend-app-library-authoring/pull/2

**Discussions**: https://docs.google.com/document/d/1hRrSmWWlGHhi-bh9AIlpSuLtJFnn2GpavNe8OQxthbE/edit

**Dependencies**: https://github.com/edx/frontend-app-library-authoring/pull/7

**Screenshots**: 
![Screen Shot 2020-09-04 at 10 42 20 AM](https://user-images.githubusercontent.com/1099483/92257907-97107080-ee9b-11ea-9ae7-cde291923ff5.png)
![Screen Shot 2020-09-04 at 10 42 41 AM](https://user-images.githubusercontent.com/1099483/92257919-9d9ee800-ee9b-11ea-83aa-9ff95f466164.png)
![Screen Shot 2020-09-04 at 10 42 57 AM](https://user-images.githubusercontent.com/1099483/92257925-a1326f00-ee9b-11ea-820a-566dc8826040.png)

**Merge deadline**: No hard deadline, but sooner is better than later.

**Testing instructions**:

1. Use the `edx-platform` branch `open-craft:fox/se-2931-user-access-adjustments` on the backend.
1. Follow the directions in https://github.com/edx/frontend-app-library-authoring/pull/4 up until item 15.
1. Create a new library of the 'complex' type.
1. In the top menu, there should be a 'User Access' link. Click it to visit the user access page.
1. Create and remove users, elevate their access, and depriv them. Verify the form resets upon add and that the user is added to the list.
1. Put bogus users and data into the email field to verify errors are handled well.
1. Delete users. Note, you should be able to delete yourself as a staff member, and still readd yourself, despite not having labeled privileges.
1. Verify that the interface does not let you remove or depriv yourself if there is no secondary admin.
1. Elevate a user who is not marked is_staff or is_superuser to 'staff' within the interface (that is, library author-- not marking them is_staff in the admin), and have them log in. Verify that the access control buttons are not present.


**Author notes and concerns**:

1. This is the largest amount of React code I've had to make so far, and the first time I've done real full component dev-- previously I modified other components. This is also my first time with Redux. I'd like feedback on how well I'm using those tools.
2. This task initially had an implementation similar to other pages currently in the repository. However, after speaking with @bradenmacdonald , he suggested using [the container pattern](https://www.freecodecamp.org/news/react-superpowers-container-pattern-20d664bdae65/) so that unit tests may be more easily written next sprint. This is my first time using this pattern and so I'd like his review to make sure I'm using/understanding it well.
3. It's been a while since I've done anything a11y related-- we're using paragon, which I believe is able to automate much of it, but I'd like to make sure I understand if I'm assuming its capabilities to be greater than they are in the code I'm writing, since I haven't immediately thought of any markup I'd have to customize here.

**Reviewers**
- [ ] @mavidser 
- [x] @bradenmacdonald 
- [x] @kdmccormick
