### PR TITLE
[BD-14] Handle field-based errors for XBlock addition properly.

### DIFF
--- a/src/library-authoring/common/helpers.js
+++ b/src/library-authoring/common/helpers.js
@@ -1,0 +1,36 @@
+/**
+ * Normalizes, and rethrows, errors that are returned from the HTTP client.
+ * @param error
+ */
+// eslint-disable-next-line import/prefer-default-export
+export function normalizeErrors(error) {
+  const apiError = Object.create(error);
+  let errorData;
+  try {
+    errorData = JSON.parse(error.customAttributes.httpErrorResponseData);
+  } catch {
+    apiError.fields = null;
+    // Empty message will trigger a default error message in the template.
+    apiError.message = '';
+    throw apiError;
+  }
+  // Default Django REST error text slot. Used for things like the
+  // default 'not found' response from get_object_or_404.
+  if (errorData.detail) {
+    apiError.fields = null;
+    apiError.message = errorData.detail;
+  } else if (typeof errorData === 'string') {
+    // This is an error not from Django REST. Some part of the stack is unaware it should be sending back JSON.
+    apiError.fields = null;
+    apiError.message = '';
+  } else if (Array.isArray(errorData)) {
+    // Error is non field-bound ValidationError on the backend.
+    apiError.fields = null;
+    apiError.message = errorData.join('. ');
+  } else {
+    // We have per-field error messages.
+    apiError.fields = errorData;
+    apiError.message = null;
+  }
+  throw apiError;
+}

--- a/src/library-authoring/common/messages.js
+++ b/src/library-authoring/common/messages.js
@@ -31,6 +31,11 @@ const messages = defineMessages({
     defaultMessage: 'Yes.',
     description: 'Default label for "Yes" on a confirmation prompt.',
   },
+  'library.server.error.generic': {
+    id: 'library.server.error.generic',
+    defaultMessage: 'We had an issue contacting the server. Please try again later!',
+    description: 'Default error message when contacting server.',
+  },
 });
 
 export default messages;

--- a/src/library-authoring/library-detail/data/api.js
+++ b/src/library-authoring/library-detail/data/api.js
@@ -1,5 +1,6 @@
 import { ensureConfig, getConfig } from '@edx/frontend-platform';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+import { normalizeErrors } from '../../common/helpers';
 
 ensureConfig(['STUDIO_BASE_URL'], 'library API service');
 
@@ -26,18 +27,13 @@ export async function getLibraryDetail(libraryId) {
   return library;
 }
 
-export async function createLibraryBlock({ libraryId, ...data }) {
+export async function createLibraryBlock({ libraryId, data }) {
   const client = getAuthenticatedHttpClient();
   const baseUrl = getConfig().STUDIO_BASE_URL;
   const response = await client.post(
     `${baseUrl}/api/libraries/v2/${libraryId}/blocks/`,
     data,
-  ).catch((error) => {
-    /* Normalize error data. */
-    const apiError = Object.create(error);
-    [apiError.message] = JSON.parse(error.customAttributes.httpErrorResponseData);
-    throw apiError;
-  });
+  ).catch(normalizeErrors);
 
   return response.data;
 }

--- a/src/library-authoring/library-detail/data/slice.js
+++ b/src/library-authoring/library-detail/data/slice.js
@@ -8,6 +8,7 @@ export const libraryDetailStoreName = 'libraryDetail';
 
 export const libraryDetailInitialState = {
   errorMessage: null,
+  errorFields: null,
   library: null,
   status: LOADING_STATUS.LOADING,
 };
@@ -38,6 +39,11 @@ const slice = createSlice({
         has_unpublished_changes: { $set: true },
         blocks: { $push: [payload.libraryBlock] },
       });
+    },
+    libraryCreateBlockFailed: (state, { payload }) => {
+      state.status = LOADING_STATUS.FAILED;
+      state.errorMessage = payload.errorMessage;
+      state.errorFields = payload.errorFields;
     },
   },
 });

--- a/src/library-authoring/library-detail/data/thunks.js
+++ b/src/library-authoring/library-detail/data/thunks.js
@@ -13,13 +13,13 @@ export const fetchLibraryDetail = ({ libraryId }) => async (dispatch) => {
   }
 };
 
-export const createLibraryBlock = ({ data }) => async (dispatch) => {
+export const createLibraryBlock = ({ libraryId, data }) => async (dispatch) => {
   try {
     dispatch(actions.libraryDetailRequest());
-    const libraryBlock = await api.createLibraryBlock(data);
+    const libraryBlock = await api.createLibraryBlock({ libraryId, data });
     dispatch(actions.libraryCreateBlockSuccess({ libraryBlock }));
   } catch (error) {
-    dispatch(actions.libraryDetailFailed({ errorMessage: error.message }));
+    dispatch(actions.libraryCreateBlockFailed({ errorMessage: error.message, errorFields: error.fields }));
     logError(error);
   }
 };

--- a/src/library-authoring/library-detail/index.scss
+++ b/src/library-authoring/library-detail/index.scss
@@ -2,3 +2,17 @@
   margin: 0;
   font-size: 1.4rem;
 }
+
+// The following to be removed when a proper interface for library authoring is fully specced out.
+// This should make error messages visible in the mean time.
+.library-detail-wrapper {
+  .invalid-feedback {
+    display: block;
+    background-color: $white;
+    font-size: 70%;
+    border-radius: 3px;
+  }
+  .add-xblock-component .new-component-type .add-xblock-component-button {
+    height: auto;
+  }
+}


### PR DESCRIPTION
This PR updates the XBlock submission buttons to use Paragon components and to handle error messages more properly. While we are still waiting on a future task to improve the UX for block creation and editing, we found that this components broken functionality (as well as its lack of use of accessible elements) was confusing to new developers and also left an example of what **not** to do in the code, which might be mistakenly copied.

This cleans up the error handling, making the transition to a new interface cleaner, and making sure that anyone testing using this repo can get proper feedback in case they do something like put a space in a block's description ID. It also factors out error normalizing code into its own function, which can be used elsewhere.

**Jira ticket**: https://openedx.atlassian.net/browse/BLENDED-589

**Merge deadline**: None-- honestly this could stand to wait a little while because merging it will require a rebase in other places. I'd rather rebase this one later than those ones.

**Screenshots**
![Screen Shot 2020-09-15 at 12 27 19 PM](https://user-images.githubusercontent.com/1099483/93245571-1d0ca100-f751-11ea-80b9-f46dc8a0ee4a.png)
![Screen Shot 2020-09-15 at 12 29 46 PM](https://user-images.githubusercontent.com/1099483/93245580-20a02800-f751-11ea-891e-287b418e44b9.png)


**Testing instructions**:

1. Submit a new block with a space in the name. Verify a useful error is generated.
2. Submit a new block with each of the following changes to studio in place. In each case, the frontend should do something useful.
    1. Force the Studio to throw Http404.
    2. Force the Studio to throw ValidationError('This is a test.')
    3. Force the studio to raise an uncaught exception, like RuntimeError.
    4. Shut down the studio.

**Reviewers**
- [ ] @arbrandes 
- [ ] edX reviewer[s] TBD