### PR TITLE
[BD-14] [SE-2932] Add a license field to libraries. 

### DIFF
--- a/src/library-authoring/common/License.jsx
+++ b/src/library-authoring/common/License.jsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import {
+  faCreativeCommonsBy,
+  faCreativeCommonsNc,
+  faCreativeCommonsNd,
+  faCreativeCommonsSa,
+} from '@fortawesome/free-brands-svg-icons';
+import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { commonsOptionsFromSpec, commonsOptionsShape, linkFromSpec } from './data';
+import messages from './messages';
+
+
+/**
+ * CreativeCommonsLicense
+ * Displays a Creative Commons license in an accessible manner.
+ */
+export const CreativeCommonsLicenseBase = ({ intl, link, commonsOptions }) => (
+  <a href={link} target="_blank" rel="noopener noreferrer license">
+    <span className="sr-only">
+      {intl.formatMessage(messages['library.common.license.cc.preface'])}
+    </span>
+    {commonsOptions.attribution && (
+      <>
+        <span className="sr-only">{intl.formatMessage(messages['library.common.license.cc.attribution'])}</span>
+        <FontAwesomeIcon icon={faCreativeCommonsBy} className="aria-hidden mr-1" />
+      </>
+    )}
+    {commonsOptions.nonCommercial && (
+      <>
+        <span className="sr-only">{intl.formatMessage(messages['library.common.license.cc.noncommercial'])}</span>
+        <FontAwesomeIcon icon={faCreativeCommonsNc} className="aria-hidden mx-1" />
+      </>
+    )}
+    {commonsOptions.noDerivatives && (
+      <>
+        <span className="sr-only">{intl.formatMessage(messages['library.common.license.cc.no_derivatives'])}</span>
+        <FontAwesomeIcon icon={faCreativeCommonsNd} className="aria-hidden mx-1" />
+      </>
+    )}
+    {commonsOptions.shareAlike && (
+      <>
+        <span className="sr-only">{intl.formatMessage(messages['library.common.license.cc.share_alike'])}</span>
+        <FontAwesomeIcon icon={faCreativeCommonsSa} className="aria-hidden mx-1" />
+      </>
+    )}
+    <strong>{intl.formatMessage(messages['library.common.license.cc.postscript'])}</strong>
+  </a>
+);
+
+CreativeCommonsLicenseBase.propTypes = {
+  intl: intlShape.isRequired,
+  link: PropTypes.string.isRequired,
+  commonsOptions: commonsOptionsShape.isRequired,
+};
+
+export const CreativeCommonsLicense = injectIntl(CreativeCommonsLicenseBase);
+
+
+/**
+ * Displays an 'All Rights Reserved' tag.
+ */
+export const AllRightsReservedBase = ({ intl }) => (
+  <strong>{intl.formatMessage(messages['library.common.license.none'])}</strong>
+);
+
+AllRightsReservedBase.propTypes = {
+  intl: intlShape.isRequired,
+};
+
+export const AllRightsReserved = injectIntl(AllRightsReservedBase);
+
+/**
+ * LicenseContainer
+ * Given a string representing the license, either empty or in the form of a creative commons string,
+ * displays an accessible license stamp with relevant URL if applicable.
+ */
+export const LicenseContainer = ({ spec }) => {
+  const link = spec && linkFromSpec(spec);
+  const commonsOptions = commonsOptionsFromSpec(spec);
+  // No link, blank license. A blank license is All Rights Reserved.
+  if (!link) {
+    return <AllRightsReserved />;
+  }
+  return <CreativeCommonsLicense link={link} commonsOptions={commonsOptions} />;
+};
+
+LicenseContainer.propTypes = {
+  spec: PropTypes.string.isRequired,
+};

--- a/src/library-authoring/common/LicenseField.jsx
+++ b/src/library-authoring/common/LicenseField.jsx
@@ -1,0 +1,231 @@
+import React, { useCallback, useState } from 'react';
+import PropTypes from 'prop-types';
+import {
+  Button,
+  Col,
+  Input,
+  Row,
+} from '@edx/paragon';
+import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { LicenseContainer } from './License';
+import {
+  commonsOptionsFromSpec,
+  specFromCommonsOptions,
+  withCommonsOption,
+} from './data';
+import messages from './messages';
+
+/**
+ * LicenseField
+ * Template component for the license field used in library creation and editing. Managed by LicenseFieldContainer.
+ */
+export const LicenceFieldBase = (
+  {
+    intl,
+    reservedVariant,
+    commonsVariant,
+    updateValue,
+    value,
+    spec,
+    updateFlags,
+    commonsOptions,
+    name,
+  },
+) => (
+  <div>
+    <label htmlFor={name}>
+      {intl.formatMessage(messages['library.common.fields.license.label'])}
+    </label>
+    <Row className="flex-row">
+      <Col>
+        <Button name={name} className="text-uppercase mx-1" variant={reservedVariant} size="lg" onClick={() => updateValue('')}>
+          {intl.formatMessage(messages['library.common.license.none'])}
+        </Button>
+      </Col>
+      <Col>
+        <Button name={name} className="text-uppercase mx-1" variant={commonsVariant} size="lg" onClick={() => updateValue(spec)}>
+          {intl.formatMessage(messages['library.common.license.cc'])}
+        </Button>
+        <p className="small">
+          <a target="_blank" rel="noopener noreferrer" href="https://creativecommons.org/about">
+            {intl.formatMessage(messages['library.common.fields.license.cc.learn_more'])}
+          </a>
+        </p>
+      </Col>
+    </Row>
+    {value && (
+      <>
+        <div className="pt-5">
+          <strong>{intl.formatMessage(messages['library.common.fields.license.cc.options'])}</strong>
+        </div>
+        <Row className="border-bottom py-2">
+          <Col xs={1} className="text-center align-self-center">
+            <Input
+              type="checkbox"
+              id="attribution"
+              name="attribution"
+              className="m-0 p-0 position-relative"
+              disabled
+              checked
+            />
+          </Col>
+          <Col xs={2} className="text-left align-self-center">
+            <label htmlFor="attribution">
+              {intl.formatMessage(messages['library.common.license.cc.attribution'])}
+            </label>
+          </Col>
+          <Col xs={9} className="align-self-center">
+            {intl.formatMessage(messages['library.common.fields.license.cc.attribution'])}
+          </Col>
+        </Row>
+        <Row className="border-bottom py-2">
+          <Col xs={1} className="text-center align-self-center">
+            <Input
+              type="checkbox"
+              id="nonCommercial"
+              name="nonCommercial"
+              className="m-0 p-0 position-relative"
+              onChange={updateFlags}
+              checked={commonsOptions.nonCommercial}
+            />
+          </Col>
+          <Col xs={2} className="text-left align-self-center">
+            <label htmlFor="nonCommercial">
+              {intl.formatMessage(messages['library.common.license.cc.noncommercial'])}
+            </label>
+          </Col>
+          <Col xs={9} className="align-self-center">
+            {intl.formatMessage(messages['library.common.fields.license.cc.noncommercial'])}
+          </Col>
+        </Row>
+        <Row className="border-bottom py-2">
+          <Col xs={1} className="text-center align-self-center">
+            <Input
+              type="checkbox"
+              name="noDerivatives"
+              id="noDerivatives"
+              className="m-0 p-0 position-relative"
+              onChange={updateFlags}
+              checked={commonsOptions.noDerivatives}
+            />
+          </Col>
+          <Col xs={2} className="text-left align-self-center">
+            <label htmlFor="noDerivatives">
+              {intl.formatMessage(messages['library.common.license.cc.no_derivatives'])}
+            </label>
+          </Col>
+          <Col xs={9} className="align-self-center">
+            {intl.formatMessage(messages['library.common.fields.license.cc.no_derivatives'])}
+          </Col>
+        </Row>
+        <Row className="border-bottom py-2">
+          <Col xs={1} className="text-center align-self-center">
+            <Input
+              type="checkbox"
+              id="shareAlike"
+              name="shareAlike"
+              className="m-0 p-0 position-relative"
+              onChange={updateFlags}
+              checked={commonsOptions.shareAlike}
+            />
+          </Col>
+          <Col xs={2} className="text-left align-self-center">
+            <label htmlFor="shareAlike">
+              {intl.formatMessage(messages['library.common.license.cc.share_alike'])}
+            </label>
+          </Col>
+          <Col xs={9} className="align-self-center">
+            {intl.formatMessage(messages['library.common.fields.license.cc.share_alike'])}
+          </Col>
+        </Row>
+      </>
+    )}
+    <Row className="mt-2">
+      <Col xs={12}>
+        <h3>License Preview</h3>
+        <p>The following message will be displayed where appropriate:</p>
+      </Col>
+      <Col xs={12}>
+        <LicenseContainer spec={value} />
+      </Col>
+    </Row>
+  </div>
+);
+
+
+LicenceFieldBase.propTypes = {
+  intl: intlShape.isRequired,
+  reservedVariant: PropTypes.string.isRequired,
+  commonsVariant: PropTypes.string.isRequired,
+  updateFlags: PropTypes.func.isRequired,
+  commonsOptions: PropTypes.shape({
+    attribution: PropTypes.bool.isRequired,
+    nonCommercial: PropTypes.bool.isRequired,
+    noDerivatives: PropTypes.bool.isRequired,
+    shareAlike: PropTypes.bool.isRequired,
+  }).isRequired,
+  value: PropTypes.string.isRequired,
+  spec: PropTypes.string.isRequired,
+  updateValue: PropTypes.func.isRequired,
+  name: PropTypes.string.isRequired,
+};
+
+// We inject later because code introspection tools get confused about 'intl' otherwise.
+export const LicenseField = injectIntl(LicenceFieldBase);
+
+
+/**
+ * LicenseFieldContainer
+ * Container for the LicenseField-- dynamically displays the license options and allows a user to toggle features
+ * for supported licenses.
+ */
+export const LicenseFieldContainerBase = ({ value, updateValue, name }) => {
+  // We need to remember these values. If the user switches away from Creative Commons, we should remember what
+  // checkboxes were checked.
+  const [cachedSpec, updateCache] = useState(value);
+  const commonsOptions = commonsOptionsFromSpec(cachedSpec);
+  let commonVariant;
+  let reservedVariant;
+  if (value) {
+    commonVariant = 'primary';
+    reservedVariant = 'light';
+  } else {
+    commonVariant = 'light';
+    reservedVariant = 'primary';
+  }
+
+  const spec = specFromCommonsOptions(commonsOptions);
+
+  const updateFlags = useCallback((event) => {
+    const el = event.target;
+    const result = withCommonsOption(commonsOptions, el.name, el.checked);
+    const newSpec = specFromCommonsOptions(result);
+    updateValue(newSpec);
+    updateCache(newSpec);
+  }, [commonsOptions]);
+
+  return (
+    <LicenseField
+      commonsVariant={commonVariant}
+      reservedVariant={reservedVariant}
+      commonsOptions={commonsOptions}
+      updateFlags={updateFlags}
+      value={value}
+      spec={spec}
+      updateValue={updateValue}
+      name={name}
+    />
+  );
+};
+
+LicenseFieldContainerBase.propTypes = {
+  value: PropTypes.string.isRequired,
+  updateValue: PropTypes.func.isRequired,
+  name: PropTypes.string,
+};
+
+LicenseFieldContainerBase.defaultProps = {
+  name: 'license',
+};
+
+export const LicenseFieldContainer = injectIntl(LicenseFieldContainerBase);

--- a/src/library-authoring/common/data/constants.js
+++ b/src/library-authoring/common/data/constants.js
@@ -87,3 +87,6 @@ export const BLOCK_TYPE_EDIT_DENYLIST = [
   'videoalpha',
   'word_cloud',
 ];
+
+// This is the only version we support right now.
+export const CC_LICENSE_VERSION = '4.0';

--- a/src/library-authoring/common/data/shapes.js
+++ b/src/library-authoring/common/data/shapes.js
@@ -21,8 +21,16 @@ export const libraryShape = PropTypes.shape({
   title: PropTypes.string.isRequired,
   description: PropTypes.string,
   version: PropTypes.number,
+  license: PropTypes.string.isRequired,
   has_unpublished_changes: PropTypes.bool.isRequired,
   has_unpublished_deletes: PropTypes.bool.isRequired,
   blocks: PropTypes.arrayOf(libraryBlockShape),
   blockTypes: PropTypes.arrayOf(libraryBlockTypeShape),
+});
+
+export const commonsOptionsShape = PropTypes.shape({
+  attribution: PropTypes.bool.isRequired,
+  nonCommercial: PropTypes.bool.isRequired,
+  noDerivatives: PropTypes.bool.isRequired,
+  shareAlike: PropTypes.bool.isRequired,
 });

--- a/src/library-authoring/common/data/utils.js
+++ b/src/library-authoring/common/data/utils.js
@@ -1,6 +1,6 @@
 import { ensureConfig, getConfig } from '@edx/frontend-platform';
 
-import { LIBRARY_TYPES, BLOCK_TYPE_DENYLIST } from './constants';
+import { LIBRARY_TYPES, BLOCK_TYPE_DENYLIST, CC_LICENSE_VERSION } from './constants';
 
 ensureConfig(['STUDIO_BASE_URL'], 'library utils');
 
@@ -60,4 +60,128 @@ export const unpackLibraryKey = (key) => {
 /** Truncate an error message to 255 characters if it's longer than that. */
 export const truncateErrorMessage = (errorMessage) => (
   errorMessage.length > 255 ? `${errorMessage.substring(0, 255)}...` : errorMessage
+);
+
+
+const tagMap = [
+  ['attribution', 'BY'],
+  ['nonCommercial', 'NC'],
+  ['noDerivatives', 'ND'],
+  ['shareAlike', 'SA'],
+];
+
+// Some flags for Creative Commons are mutually exclusive.
+const exclusiveMap = {
+  noDerivatives: 'shareAlike',
+  shareAlike: 'noDerivatives',
+};
+
+const defaultFlags = {
+  attribution: true,
+  nonCommercial: false,
+  noDerivatives: false,
+  shareAlike: false,
+};
+
+const optionsMatchers = {
+  // Always required. Don't give the chance for junk data to break this.
+  attribution: /.*/,
+  nonCommercial: /:NC(:|$)/,
+  noDerivatives: /:ND(:|$)/,
+  shareAlike: /:SA(:|$)/,
+};
+
+/**
+ * @typedef {{noDerivatives: boolean, nonCommercial: boolean, attribution: boolean, shareAlike: boolean}} CommonsOptions
+ */
+
+
+/**
+ * Given a current set of options for Creative Commons, change the flag to the requested value and return
+ * a new object with the result. This makes sure mutually exclusive flags are turned off.
+ *
+ * @param {CommonsOptions} commonsOptions
+ * @param {string} key
+ * @param {boolean} value
+ * @returns {CommonsOptions}
+ */
+export const withCommonsOption = (commonsOptions, key, value) => {
+  const results = {
+    ...commonsOptions,
+  };
+  results[key] = value;
+  const remove = exclusiveMap[key];
+  if (value && remove) {
+    results[remove] = false;
+  }
+  return results;
+};
+
+/**
+ * Given a license spec string, like 'CC:4.0:SA:NC', derive the Creative Commons options the license declares.
+ * @param {string} spec
+ * @returns {CommonsOptions}
+ */
+export const commonsOptionsFromSpec = (spec) => {
+  let results = { ...defaultFlags };
+  Object.keys(optionsMatchers).forEach((key) => {
+    if (spec.match(optionsMatchers[key])) {
+      results = withCommonsOption(results, key, true);
+      // Make sure if we're adding a flag, that we turn off any mutually exclusive flag.
+      if (exclusiveMap[key]) {
+        results[exclusiveMap[key]] = false;
+      }
+    }
+  });
+  return results;
+};
+
+/**
+ * flagsFromCommonsOptions
+ * Given a CommonsOptions object, returns an array of flags for Creative Commons licenses in their
+ * expected order.
+ * @param {CommonsOptions} commonsOptions
+ * @returns {string[]}
+ */
+export const flagsFromCommonsOptions = (commonsOptions) => {
+  const flags = [];
+  // Construct the flags in a consistent order
+  tagMap.forEach(([propName, sym]) => {
+    if (commonsOptions[propName]) {
+      flags.push(sym);
+    }
+  });
+  return flags;
+};
+
+/**
+ * Given a CommonsOptions object, returns a license 'spec' (string) that can be desconstructed back into a set of
+ * CommonsOptions if needed for easy DB storage and internationalization.
+ * @param {CommonsOptions} commonsOptions
+ * @returns {string}
+ */
+export const specFromCommonsOptions = (commonsOptions) => {
+  const specSections = ['CC', CC_LICENSE_VERSION];
+  specSections.push(...flagsFromCommonsOptions(commonsOptions));
+  return specSections.join(':');
+};
+
+/**
+ * Given a set of flags, constructs the URL for the relevant creative commons license.
+ * @param {string[]} flags
+ * @returns {string}
+ */
+export const linkFromFlags = (flags) => (
+  `https://creativecommons.org/licenses/${flags.join('-').toLowerCase()}/${CC_LICENSE_VERSION}/`
+);
+
+/**
+ * Clearly named convenience function for turning a license spec string into a link.
+ * @param {string} spec
+ * @returns {string}
+ */
+export const linkFromSpec = (spec) => linkFromFlags(
+  flagsFromCommonsOptions(
+    commonsOptionsFromSpec(spec),
+  ),
 );

--- a/src/library-authoring/common/messages.js
+++ b/src/library-authoring/common/messages.js
@@ -36,6 +36,85 @@ const messages = defineMessages({
     defaultMessage: 'We had an issue contacting the server. Please try again later!',
     description: 'Default error message when contacting server.',
   },
+  'library.common.fields.license.label': {
+    id: 'library.common.fields.license.label',
+    defaultMessage: 'License Type',
+    description: 'Label for license type field.',
+  },
+  'library.common.fields.license.cc.learn_more': {
+    id: 'library.common.fields.license.learn_more',
+    defaultMessage: 'Learn more about Creative Commons',
+    description: 'Invitation to learn more about Creative Commons.',
+  },
+  'library.common.fields.license.cc.options': {
+    id: 'library.common.fields.license.cc.options',
+    defaultMessage: 'Options for Creative Commons',
+    description: 'Header for the list of Creative Commons options.',
+  },
+  'library.common.fields.license.cc.attribution': {
+    id: 'library.common.fields.license.attribution',
+    defaultMessage: 'Allow others to copy, distribute, display and perform your copyrighted work but only if they '
+      + 'give credit the way you request. Currently, this option is required.',
+    description: 'Description of the \'attribution\' (BY) option for Creative Commons Licenses.',
+  },
+  'library.common.fields.license.cc.noncommercial': {
+    id: 'library.common.fields.license.noncommercial',
+    defaultMessage: 'Allow others to copy, distribute, display and perform your work - and derivative works based '
+      + 'upon it - but for noncommercial purposes only.',
+    description: 'Description of the \'noncommercial\' (NC) option for Creative Commons Licenses.',
+  },
+  'library.common.fields.license.cc.no_derivatives': {
+    id: 'library.common.fields.license.no_derivatives',
+    defaultMessage: 'Allow others to copy, distribute, display and perform only verbatim copies of your work, not '
+      + 'derivative works based upon it. This option is incompatible with "Share Alike".',
+    description: 'Description of the \'no derivatives\' (ND) option for Creative Commons Licenses.',
+  },
+  'library.common.fields.license.cc.share_alike': {
+    id: 'library.common.fields.license.share_alike',
+    defaultMessage: 'Allow others to distribute derivative works only under a license identical to the license that '
+      + 'governs your work. This option is incompatible with "No Derivatives".',
+    description: 'Description of the \'no derivatives\' (ND) option for Creative Commons Licenses.',
+  },
+  'library.common.license.cc': {
+    id: 'library.common.license.cc',
+    defaultMessage: 'Creative Commons',
+    description: 'Label for Creative Commons license types.',
+  },
+  'library.common.license.cc.preface': {
+    id: 'library.common.license.cc.preface',
+    defaultMessage: 'Creative Commons licensed content, with terms as follows:',
+    description: 'Preface message introducing the terms of the current Creative Commons license. Screen readers only.',
+  },
+  'library.common.license.cc.attribution': {
+    id: 'library.common.license.cc.attribution',
+    defaultMessage: 'Attribution',
+    description: 'Label for the Creative Commons \'attribution\' (BY) modifier.',
+  },
+  'library.common.license.cc.noncommercial': {
+    id: 'library.common.license.cc.noncommercial',
+    defaultMessage: 'Noncommercial',
+    description: 'Label for the Creative Commons \'noncommercial\' (NC) modifier.',
+  },
+  'library.common.license.cc.no_derivatives': {
+    id: 'library.common.license.cc.no_derivatives',
+    defaultMessage: 'No Derivatives',
+    description: 'Label for the Creative Commons \'no derivatives\' (ND) modifier.',
+  },
+  'library.common.license.cc.share_alike': {
+    id: 'library.common.license.cc.share_alike',
+    defaultMessage: 'Share Alike',
+    description: 'Label for the Creative Commons \'share alikes\' (SA) modifier.',
+  },
+  'library.common.license.cc.postscript': {
+    id: 'library.common.license.cc.postscript',
+    defaultMessage: 'Some Rights Reserved.',
+    description: 'Postscript message after showing the attributes for a Creative Commons license.',
+  },
+  'library.common.license.none': {
+    id: 'library.common.license.none',
+    defaultMessage: 'All Rights Reserved',
+    description: 'Text/Label for a license where all rights are reserved.',
+  },
 });
 
 export default messages;

--- a/src/library-authoring/create-library/LibraryCreateForm.jsx
+++ b/src/library-authoring/create-library/LibraryCreateForm.jsx
@@ -23,6 +23,7 @@ import {
 
 import commonMessages from '../common/messages';
 import messages from './messages';
+import { LicenseFieldContainer } from '../common/LicenseField';
 
 class LibraryCreateForm extends React.Component {
   constructor(props) {
@@ -34,6 +35,7 @@ class LibraryCreateForm extends React.Component {
         org: '',
         slug: '',
         type: LIBRARY_TYPES.COMPLEX,
+        license: '',
       },
     };
   }
@@ -68,6 +70,8 @@ class LibraryCreateForm extends React.Component {
       },
     }));
   }
+
+  mockInputChange = (name) => (value) => this.onValueChange({ target: { value, name, type: 'text' } })
 
   onCancel = () => {
     this.props.resetForm();
@@ -231,6 +235,13 @@ class LibraryCreateForm extends React.Component {
                   onChange={this.onValueChange}
                 />
               </ValidationFormGroup>
+            </li>
+            <li className={`field ${(data.type === 'legacy' && 'd-none') || ''}`}>
+              { /* Retain caching capabilities by hiding rather than removing this field. */ }
+              <LicenseFieldContainer
+                value={data.license}
+                updateValue={this.mockInputChange('license')}
+              />
             </li>
           </ol>
         </fieldset>

--- a/src/library-authoring/edit-library/LibraryEditPage.jsx
+++ b/src/library-authoring/edit-library/LibraryEditPage.jsx
@@ -19,7 +19,8 @@ import {
   LOADING_STATUS,
   SUBMISSION_STATUS,
   libraryShape,
-  truncateErrorMessage, LIBRARY_TYPES,
+  truncateErrorMessage,
+  LIBRARY_TYPES,
 } from '../common';
 import {
   fetchLibraryDetail,
@@ -31,6 +32,7 @@ import {
   updateLibrary,
 } from './data';
 import messages from './messages';
+import { LicenseFieldContainer } from '../common/LicenseField';
 
 class LibraryEditPage extends React.Component {
   constructor(props) {
@@ -43,6 +45,7 @@ class LibraryEditPage extends React.Component {
         type: null,
         allow_public_learning: false,
         allow_public_read: false,
+        license: null,
       },
     };
   }
@@ -79,6 +82,7 @@ class LibraryEditPage extends React.Component {
         type: library.type,
         allow_public_learning: library.allow_public_learning,
         allow_public_read: library.allow_public_read,
+        license: library.license,
       },
     });
   }
@@ -129,6 +133,8 @@ class LibraryEditPage extends React.Component {
   handleDismissAlert = () => {
     this.props.clearError();
   }
+
+  mockInputChange = (name) => (value) => this.handleValueChange({ target: { value, name, type: 'text' } })
 
   handleValueChange = (event) => {
     const el = event.target;
@@ -280,6 +286,15 @@ class LibraryEditPage extends React.Component {
                           onChange={this.handleValueChange}
                         />
                       </Form.Group>
+                    </li>
+                    <li className="field">
+                      { /* Checking null here since we cache the initial value. */ }
+                      {(data.license !== null) && (
+                        <LicenseFieldContainer
+                          value={data.license}
+                          updateValue={this.mockInputChange('license')}
+                        />
+                      )}
                     </li>
                   </ol>
                 </fieldset>

--- a/src/library-authoring/library-detail/LibraryPage.jsx
+++ b/src/library-authoring/library-detail/LibraryPage.jsx
@@ -27,6 +27,7 @@ import {
 import LibraryBlockCard from './LibraryBlockCard';
 import commonMessages from '../common/messages';
 import messages from './messages';
+import { LicenseContainer } from '../common/License';
 
 class LibraryPage extends React.Component {
   constructor(props) {
@@ -275,6 +276,8 @@ class LibraryPage extends React.Component {
                         </Button>
                       </li>
                     </ul>
+                    <h4>Library License:</h4>
+                    <LicenseContainer spec={library.license} />
                   </div>
                 </div>
               </div>

--- a/src/library-authoring/list-libraries/data/api.js
+++ b/src/library-authoring/list-libraries/data/api.js
@@ -49,6 +49,7 @@ export async function getLibraryList(params) {
         version: null,
         has_unpublished_changes: false,
         has_unpublished_deletes: false,
+        license: '',
         type: LIBRARY_TYPES.LEGACY,
       };
     });


### PR DESCRIPTION
This pull request allows library admins to set the license of their creation-- either 'All Rights Reserved' or one of the latest Creative Commons licenses. The backend PR for this change is here: https://github.com/edx/edx-platform/pull/25007

For convenience, a review version of this PR is available here: https://github.com/open-craft/frontend-app-library-authoring/pull/4

**Discussions**: https://docs.google.com/document/d/1hRrSmWWlGHhi-bh9AIlpSuLtJFnn2GpavNe8OQxthbE/edit#heading=h.x4hzuvwb0us

**Dependencies**: https://github.com/edx/frontend-app-library-authoring/pull/8

![Screen Shot 2020-09-17 at 11 24 50 AM](https://user-images.githubusercontent.com/1099483/93499445-9f739d00-f8d8-11ea-80e0-532f2a724b08.png)
![Screen Shot 2020-09-17 at 11 25 03 AM](https://user-images.githubusercontent.com/1099483/93499454-a3072400-f8d8-11ea-85da-a1aa2eab23a4.png)
![Screen Shot 2020-09-17 at 11 26 00 AM](https://user-images.githubusercontent.com/1099483/93499460-a5697e00-f8d8-11ea-8455-d4dd3297ae20.png)

**Merge deadline**: Sooner is better than later.

**Testing instructions**:

1. Create a new library.
    1. Verify that the license field disappears if creating a legacy type library.
    2. Verify that clicking Creative Commons gives you more options for your license.
    3. Verify that the license field remembers your options if you switch from complex/video/problem to legacy and back.
    4. Verify that creating the library results in the option being saved by visiting the newly created library's edit page.
2. Edit an existing library.
    1. Verify that you can switch libraries from one license to another and that this change is saved and persists across reloads.
    2. Verify that the mutually exclusive flags 'Share Alike' and 'No Derivatives' cannot be co-selected.
3. Verify that the library's detail page shows the current license near the publish button.

**Reviewers**
- [ ] @arbrandes 
- [ ] @kdmccormick