### PR TITLE
[BD-14] Set explicit text direction in xblock-bootstrap.html

### DIFF
--- a/src/library-authoring/edit-block/LibraryBlock/xblock-bootstrap.html
+++ b/src/library-authoring/edit-block/LibraryBlock/xblock-bootstrap.html
@@ -12,7 +12,7 @@
   its content with that HTML.
 -->
 <!DOCTYPE html>
-<html>
+<html dir="auto">
   <head>
     <meta charset="UTF-8">
   </head>


### PR DESCRIPTION
This was needed for other projects that use a similar file.  The change is a preemptive one, as i18n support is not yet fully tested in this MFE.

To test, simply pull this branch into a devstack and check that blocks are rendered with no adverse effects, as compared to without it.