### PR TITLE
Updated the build status badge to point to travis-ci.com

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,8 +54,8 @@ Internationalization
 
 Please see `edx/frontend-platform's i18n module <https://edx.github.io/frontend-platform/module-Internationalization.html>`_ for documentation on internationalization.  The documentation explains how to use it, and the `How To <https://github.com/edx/frontend-i18n/blob/master/docs/how_tos/i18n.rst>`_ has more detail.
 
-.. |Build Status| image:: https://api.travis-ci.org/edx/frontend-app-library-authoring.svg?branch=master
-   :target: https://travis-ci.org/edx/frontend-app-library-authoring
+.. |Build Status| image:: https://api.travis-ci.com/edx/frontend-app-library-authoring.svg?branch=master
+   :target: https://travis-ci.com/edx/frontend-app-library-authoring
 .. |Codecov| image:: https://codecov.io/gh/edx/frontend-app-library-authoring/branch/master/graph/badge.svg
    :target: https://codecov.io/gh/edx/frontend-app-library-authoring
 .. |license| image:: https://img.shields.io/npm/l/@edx/frontend-app-library-authoring.svg


### PR DESCRIPTION
Updated the README file.
Build status badge is now pointing to 'travis-ci.com' instead of 'travis-ci.org'
JIRA: https://openedx.atlassian.net/browse/BOM-2089