### PR TITLE
[SE-4399] feat: add LTI URL copy feature

### DIFF
--- a/src/library-authoring/author-library/LibraryAuthoringPage.jsx
+++ b/src/library-authoring/author-library/LibraryAuthoringPage.jsx
@@ -23,6 +23,7 @@ import { LibraryBlock } from '../edit-block/LibraryBlock';
 import {
   clearLibrary,
   clearLibraryError,
+  clearLibrarySuccess,
   commitLibraryChanges,
   createBlock,
   fetchBlockLtiUrl,
@@ -54,6 +55,7 @@ import { blockStatesShape, blockViewShape, fetchable } from '../edit-block/data/
 import commonMessages from '../common/messages';
 import selectLibraryDetail from '../common/data/selectors';
 import { ErrorAlert } from '../common/ErrorAlert';
+import { SuccessAlert } from '../common/SuccessAlert';
 import { LoadGuard } from '../../generic/LoadingPage';
 
 ensureConfig(['STUDIO_BASE_URL'], 'library API service');
@@ -313,7 +315,7 @@ const deriveTypeOptions = (blockTypes, intl) => {
  */
 export const LibraryAuthoringPageBase = ({
   intl, library, blockView, showPreviews, setShowPreviews,
-  sending, addBlock, revertChanges, commitChanges, hasChanges, errorMessage,
+  sending, addBlock, revertChanges, commitChanges, hasChanges, errorMessage, successMessage,
   quickAddBehavior, otherTypes, blocks, updateSearch, typeOptions, query, type,
   ...props
 }) => (
@@ -323,7 +325,6 @@ export const LibraryAuthoringPageBase = ({
         <small className="card-subtitle">{intl.formatMessage(messages['library.detail.page.heading'])}</small>
         <h1 className="page-header-title">{library.title}</h1>
       </Col>
-      <ErrorAlert errorMessage={errorMessage} onClose={props.clearLibraryError} />
       <Col xs={12} md={4} xl={3} className="text-center d-none d-md-block">
         <ButtonToggles
           setShowPreviews={setShowPreviews}
@@ -333,6 +334,8 @@ export const LibraryAuthoringPageBase = ({
           quickAddBehavior={quickAddBehavior}
         />
       </Col>
+      <ErrorAlert errorMessage={errorMessage} onClose={props.clearLibraryError} />
+      <SuccessAlert successMessage={successMessage} onClose={props.clearLibrarySuccess} />
       <Col xs={12} className="pb-5">
         <hr />
       </Col>
@@ -481,6 +484,7 @@ export const LibraryAuthoringPageBase = ({
 
 LibraryAuthoringPageBase.defaultProps = {
   errorMessage: '',
+  successMessage: null,
   blocks: null,
 };
 
@@ -505,7 +509,9 @@ LibraryAuthoringPageBase.propTypes = {
   revertChanges: PropTypes.func.isRequired,
   commitChanges: PropTypes.func.isRequired,
   errorMessage: PropTypes.string,
+  successMessage: PropTypes.string,
   clearLibraryError: PropTypes.func.isRequired,
+  clearLibrarySuccess: PropTypes.func.isRequired,
   quickAddBehavior: PropTypes.func.isRequired,
   query: PropTypes.string.isRequired,
   type: PropTypes.string.isRequired,
@@ -658,6 +664,7 @@ export const LibraryAuthoringPageContainerBase = ({
 LibraryAuthoringPageContainerBase.defaultProps = {
   library: null,
   errorMessage: null,
+  successMessage: null,
 };
 
 LibraryAuthoringPageContainerBase.propTypes = {
@@ -673,6 +680,7 @@ LibraryAuthoringPageContainerBase.propTypes = {
   commitLibraryChanges: PropTypes.func.isRequired,
   revertLibraryChanges: PropTypes.func.isRequired,
   errorMessage: PropTypes.string,
+  successMessage: PropTypes.string,
   match: PropTypes.shape({
     params: PropTypes.shape({
       libraryId: PropTypes.string.isRequired,
@@ -684,6 +692,7 @@ const LibraryAuthoringPageContainer = connect(
   selectLibraryDetail,
   {
     clearLibraryError,
+    clearLibrarySuccess,
     clearLibrary,
     createLibraryBlock: createBlock,
     commitLibraryChanges,

--- a/src/library-authoring/author-library/LibraryAuthoringPage.jsx
+++ b/src/library-authoring/author-library/LibraryAuthoringPage.jsx
@@ -73,7 +73,7 @@ export const BlockPreviewBase = ({
     <Navbar className="border">
       <Navbar.Brand>{block.display_name}</Navbar.Brand>
       <Navbar.Collapse className="justify-content-end">
-        <Button disabled={isLtiUrlGenerating} size="lg" className="mr-1" onClick={ () => { props.fetchBlockLtiUrl({ blockId: block.id }); } }>
+        <Button disabled={isLtiUrlGenerating} size="lg" className="mr-1" onClick={() => { props.fetchBlockLtiUrl({ blockId: block.id }); }}>
           <FontAwesomeIcon icon={faClipboard} className="pr-1" />
           {intl.formatMessage(messages['library.detail.block.copy_lti_url'])}
         </Button>

--- a/src/library-authoring/author-library/LibraryAuthoringPage.jsx
+++ b/src/library-authoring/author-library/LibraryAuthoringPage.jsx
@@ -75,10 +75,14 @@ export const BlockPreviewBase = ({
     <Navbar className="border">
       <Navbar.Brand>{block.display_name}</Navbar.Brand>
       <Navbar.Collapse className="justify-content-end">
-        <Button disabled={isLtiUrlGenerating} size="lg" className="mr-1" onClick={() => { props.fetchBlockLtiUrl({ blockId: block.id }); }}>
-          <FontAwesomeIcon icon={faClipboard} className="pr-1" />
-          {intl.formatMessage(messages['library.detail.block.copy_lti_url'])}
-        </Button>
+        { library.allow_lti && (
+          <>
+            <Button disabled={isLtiUrlGenerating} size="lg" className="mr-1" onClick={() => { props.fetchBlockLtiUrl({ blockId: block.id }); }}>
+              <FontAwesomeIcon icon={faClipboard} className="pr-1" />
+              {intl.formatMessage(messages['library.detail.block.copy_lti_url'])}
+            </Button>
+          </>
+        )}
         <Link to={editView}>
           <Button size="lg" className="mr-1">
             <FontAwesomeIcon icon={faEdit} className="pr-1" />

--- a/src/library-authoring/author-library/data/api.js
+++ b/src/library-authoring/author-library/data/api.js
@@ -47,6 +47,14 @@ export const getBlocks = annotateCall(async ({ libraryId, query = '', types = []
   );
 });
 
+export const getBlockLtiUrl = annotateCall(async ({ blockId }) => {
+  const client = getAuthenticatedHttpClient();
+  const baseUrl = getConfig().STUDIO_BASE_URL;
+
+  const response = await client.get(`${baseUrl}/api/libraries/v2/blocks/${blockId}/lti/`);
+  return response.data;
+});
+
 export const createLibraryBlock = annotateCall(async ({ libraryId, data }) => {
   const client = getAuthenticatedHttpClient();
   const baseUrl = getConfig().STUDIO_BASE_URL;

--- a/src/library-authoring/author-library/data/slice.js
+++ b/src/library-authoring/author-library/data/slice.js
@@ -8,6 +8,7 @@ export const libraryAuthoringInitialState = {
   errorFields: null,
   library: { status: LOADING_STATUS.STANDBY, value: null },
   blocks: { status: LOADING_STATUS.STANDBY, value: [] },
+  ltiUrlClipboard: { status: LOADING_STATUS.STANDBY, value: { blockId: null, lti_url: null } },
 };
 
 export const baseLibraryDetailReducers = {
@@ -50,6 +51,10 @@ export const baseLibraryDetailReducers = {
     state.blocks.status = LOADING_STATUS.FAILED;
     state.errorMessage = payload.errorMessage;
     state.errorFields = payload.errorFields;
+  },
+  libraryBlockLtiUrlFetchRequest: (state, { payload }) => {
+    state.ltiUrlClipboard.status = LOADING_STATUS.LOADING;
+    state.ltiUrlClipboard.value = { blockId: payload.blockId };
   },
 };
 

--- a/src/library-authoring/author-library/data/slice.js
+++ b/src/library-authoring/author-library/data/slice.js
@@ -4,6 +4,7 @@ import { createSlice } from '@reduxjs/toolkit';
 import { LOADING_STATUS, STORE_NAMES } from '../../common';
 
 export const libraryAuthoringInitialState = {
+  successMessage: null,
   errorMessage: null,
   errorFields: null,
   library: { status: LOADING_STATUS.STANDBY, value: null },
@@ -17,9 +18,10 @@ export const baseLibraryDetailReducers = {
     state[attr].status = LOADING_STATUS.LOADING;
   },
   libraryAuthoringSuccess: (state, { payload }) => {
-    const { attr, value } = payload;
+    const { attr, value, message } = payload;
     state[attr].value = value;
     state[attr].status = LOADING_STATUS.LOADED;
+    state.successMessage = message !== undefined ? message : null;
   },
   libraryAuthoringFailed: (state, { payload }) => {
     const { attr, errorMessage, errorFields } = payload;
@@ -30,6 +32,9 @@ export const baseLibraryDetailReducers = {
   libraryAuthoringClearError: (state) => {
     state.errorMessage = null;
     state.errorFields = null;
+  },
+  libraryAuthoringClearSuccess: (state) => {
+    state.successMessage = null;
   },
   libraryAuthoringPatch: (state, { payload }) => {
     state.library.value = { ...state.library, ...payload.library };

--- a/src/library-authoring/author-library/data/thunks.js
+++ b/src/library-authoring/author-library/data/thunks.js
@@ -36,6 +36,7 @@ export const fetchBlockLtiUrl = annotateThunk(({ blockId }) => async (dispatch) 
     dispatch(actions.libraryAuthoringSuccess({
       value: { blockId, lti_url: libraryBlockLtiUrl.lti_url },
       attr: 'ltiUrlClipboard',
+      message: 'LTI URL copied to clipboard.',
     }));
   } catch (error) {
     toError(dispatch, error, 'ltiUrlClipboard');
@@ -80,6 +81,10 @@ export const revertLibraryChanges = annotateThunk(({ libraryId }) => async (disp
 
 export const clearLibraryError = annotateThunk(() => async (dispatch) => {
   dispatch(actions.libraryAuthoringClearError());
+});
+
+export const clearLibrarySuccess = annotateThunk(() => async (dispatch) => {
+  dispatch(actions.libraryAuthoringClearSuccess());
 });
 
 export const clearLibrary = annotateThunk(() => async (dispatch) => {

--- a/src/library-authoring/author-library/data/thunks.js
+++ b/src/library-authoring/author-library/data/thunks.js
@@ -29,6 +29,19 @@ export const fetchBlocks = annotateThunk(({ libraryId, query }) => async (dispat
   }
 });
 
+export const fetchBlockLtiUrl = annotateThunk(({ blockId }) => async (dispatch) => {
+  try {
+    dispatch(actions.libraryBlockLtiUrlFetchRequest({ blockId }));
+    const libraryBlockLtiUrl = await api.getBlockLtiUrl({ blockId }).catch(normalizeErrors);
+    dispatch(actions.libraryAuthoringSuccess({
+      value: { blockId, lti_url: libraryBlockLtiUrl.lti_url },
+      attr: 'ltiUrlClipboard',
+    }));
+  } catch (error) {
+    toError(dispatch, error, 'ltiUrlClipboard');
+  }
+});
+
 export const createBlock = annotateThunk(({ libraryId, data }) => async (dispatch) => {
   try {
     dispatch(actions.libraryAuthoringRequest({ attr: 'blocks' }));

--- a/src/library-authoring/author-library/messages.js
+++ b/src/library-authoring/author-library/messages.js
@@ -102,6 +102,11 @@ const messages = defineMessages({
     defaultMessage: 'Discard changes',
     description: 'Text for the discard button.',
   },
+  'library.detail.block.copy_lti_url': {
+    id: 'library.detail.block.copy_lti_url',
+    defaultMessage: 'Copy LTI Url',
+    description: 'Button text for LTI URL copy button',
+  },
   'library.detail.block.edit': {
     id: 'library.detail.block.edit',
     defaultMessage: 'Edit',

--- a/src/library-authoring/author-library/specs/LibraryAuthoringPage.spec.jsx
+++ b/src/library-authoring/author-library/specs/LibraryAuthoringPage.spec.jsx
@@ -20,6 +20,8 @@ import {
   fetchLibraryDetail,
   revertLibraryChanges,
   searchLibrary,
+  fetchBlockLtiUrl,
+  libraryAuthoringActions,
 } from '../data';
 import { HTML_TYPE, PROBLEM_TYPE, VIDEO_TYPE } from '../../common/specs/constants';
 import {
@@ -37,6 +39,7 @@ const genState = (library, blocks = []) => (
         [STORE_NAMES.AUTHORING]: {
           library: { value: library, status: LOADING_STATUS.LOADED },
           blocks: { value: blocks, status: LOADING_STATUS.LOADED },
+          ltiUrlClipboard: { value: { blockId: null, lti_url: null }, status: LOADING_STATUS.STANDBY },
         },
         [STORE_NAMES.BLOCKS]: {
           blocks: blocks.reduce(toBlockInfo, {}),
@@ -120,6 +123,33 @@ testSuite('<LibraryAuthoringPageContainer />', () => {
       },
     ));
     expect(fetchLibraryBlockView.fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('Fetches block LTI URL to clipboard', async () => {
+    const library = libraryFactory();
+    const blocks = makeN(blockFactoryLine([], { library }), 2);
+
+    await render(library, genState(library, blocks));
+    expect(screen.getByText(blocks[0].display_name)).toBeTruthy();
+    expect(screen.getByText(blocks[1].display_name)).toBeTruthy();
+
+    const copyToClipboardButtons = screen.getAllByText('Copy LTI Url');
+    expect(copyToClipboardButtons.length).toBe(2);
+
+    copyToClipboardButtons[0].click();
+
+    await waitFor(() => fetchBlockLtiUrl.calls[0].dispatch(
+      libraryAuthoringActions.libraryBlockLtiUrlFetchRequest({ blockId: blocks[0].id }),
+    ));
+
+    expect(fetchBlockLtiUrl.fn).toHaveBeenCalledWith({ blockId: blocks[0].id });
+
+    await waitFor(() => fetchBlockLtiUrl.calls[0].dispatch(
+      libraryAuthoringActions.libraryAuthoringSuccess({
+        value: { blockId: blocks[0], lti_url: 'a' },
+        attr: 'ltiUrlClipboard',
+      })
+    ));
   });
 
   it('Adds a predefined block type', async () => {

--- a/src/library-authoring/author-library/specs/LibraryAuthoringPage.spec.jsx
+++ b/src/library-authoring/author-library/specs/LibraryAuthoringPage.spec.jsx
@@ -126,7 +126,7 @@ testSuite('<LibraryAuthoringPageContainer />', () => {
   });
 
   it('Fetches block LTI URL to clipboard', async () => {
-    const library = libraryFactory();
+    const library = libraryFactory({ allow_lti: true });
     const blocks = makeN(blockFactoryLine([], { library }), 2);
 
     await render(library, genState(library, blocks));
@@ -150,6 +150,18 @@ testSuite('<LibraryAuthoringPageContainer />', () => {
         attr: 'ltiUrlClipboard',
       }),
     ));
+  });
+
+  it('Copy LTI URL not shown unless it is enabled', async () => {
+    const library = libraryFactory();
+    const blocks = makeN(blockFactoryLine([], { library }), 2);
+
+    await render(library, genState(library, blocks));
+    expect(screen.getByText(blocks[0].display_name)).toBeTruthy();
+    expect(screen.getByText(blocks[1].display_name)).toBeTruthy();
+
+    const copyToClipboardButtons = screen.queryAllByAltText('Copy LTI Url');
+    expect(copyToClipboardButtons.length).toBe(0);
   });
 
   it('Adds a predefined block type', async () => {

--- a/src/library-authoring/author-library/specs/LibraryAuthoringPage.spec.jsx
+++ b/src/library-authoring/author-library/specs/LibraryAuthoringPage.spec.jsx
@@ -148,7 +148,7 @@ testSuite('<LibraryAuthoringPageContainer />', () => {
       libraryAuthoringActions.libraryAuthoringSuccess({
         value: { blockId: blocks[0], lti_url: 'a' },
         attr: 'ltiUrlClipboard',
-      })
+      }),
     ));
   });
 

--- a/src/library-authoring/common/SuccessAlert.jsx
+++ b/src/library-authoring/common/SuccessAlert.jsx
@@ -3,24 +3,23 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { injectIntl } from '@edx/frontend-platform/i18n';
 import { truncateMessage } from './data';
-import commonMessages from './messages';
 
 // eslint-disable-next-line import/prefer-default-export
-export const ErrorAlert = injectIntl(({ intl, errorMessage, onClose }) => (
-  errorMessage !== null && (
+export const SuccessAlert = injectIntl(({ successMessage, onClose }) => (
+  successMessage !== null && (
     <Col xs={12} className="mt-4">
       <Alert
-        variant="danger"
+        variant="success"
         onClose={onClose}
         dismissible
       >
-        {truncateMessage(errorMessage || intl.formatMessage(commonMessages['library.server.error.generic']))}
+        {truncateMessage(successMessage)}
       </Alert>
     </Col>
   )
 ));
 
-ErrorAlert.propTypes = {
-  errorMessage: PropTypes.string,
+SuccessAlert.propTypes = {
+  successMessage: PropTypes.string,
   onClose: PropTypes.func.isRequired,
 };

--- a/src/library-authoring/common/data/shapes.js
+++ b/src/library-authoring/common/data/shapes.js
@@ -25,6 +25,7 @@ export const libraryShape = PropTypes.shape({
   has_unpublished_changes: PropTypes.bool.isRequired,
   has_unpublished_deletes: PropTypes.bool.isRequired,
   blockTypes: PropTypes.arrayOf(libraryBlockTypeShape),
+  allow_lti: PropTypes.bool.isRequired,
 });
 
 export const commonsOptionsShape = PropTypes.shape({

--- a/src/library-authoring/common/data/utils.js
+++ b/src/library-authoring/common/data/utils.js
@@ -58,9 +58,9 @@ export const unpackLibraryKey = (key) => {
   };
 };
 
-/** Truncate an error message to 255 characters if it's longer than that. */
-export const truncateErrorMessage = (errorMessage) => (
-  errorMessage.length > 255 ? `${errorMessage.substring(0, 255)}...` : errorMessage
+/** Truncate a message to 255 characters if it's longer than that. */
+export const truncateMessage = (message) => (
+  message.length > 255 ? `${message.substring(0, 255)}...` : message
 );
 
 const tagMap = [

--- a/src/library-authoring/common/specs/factories.js
+++ b/src/library-authoring/common/specs/factories.js
@@ -38,6 +38,7 @@ export function libraryFactory(overrides = undefined) {
     type: LIBRARY_TYPES.COMPLEX,
     license: '',
     blockTypes: [VIDEO_TYPE, POLL_TYPE, HTML_TYPE, PROBLEM_TYPE],
+    allow_lti: false,
     ...overrides,
   };
   return {

--- a/src/library-authoring/configure-library/LibraryConfigurePage.jsx
+++ b/src/library-authoring/configure-library/LibraryConfigurePage.jsx
@@ -19,7 +19,7 @@ import {
   LOADING_STATUS,
   SUBMISSION_STATUS,
   libraryShape,
-  truncateErrorMessage,
+  truncateMessage,
   LIBRARY_TYPES,
 } from '../common';
 import {
@@ -196,7 +196,7 @@ class LibraryConfigurePage extends React.Component {
                 onClose={this.handleDismissAlert}
                 dismissible
               >
-                {truncateErrorMessage(errorMessage)}
+                {truncateMessage(errorMessage)}
               </Alert>
               )}
               <Form onSubmit={this.handleSubmit} className="form-create">

--- a/src/library-authoring/create-library/LibraryCreateForm.jsx
+++ b/src/library-authoring/create-library/LibraryCreateForm.jsx
@@ -11,7 +11,7 @@ import {
   LIBRARY_TYPES,
   SUBMISSION_STATUS,
   libraryShape,
-  truncateErrorMessage,
+  truncateMessage,
 } from '../common';
 import {
   clearFormError,
@@ -145,7 +145,7 @@ class LibraryCreateForm extends React.Component {
             onClose={this.handleDismissAlert}
             dismissible
           >
-            {truncateErrorMessage(errorMessage)}
+            {truncateMessage(errorMessage)}
           </Alert>
           )}
           <ol className="list-input">

--- a/src/library-authoring/edit-block/LibraryBlockPage.jsx
+++ b/src/library-authoring/edit-block/LibraryBlockPage.jsx
@@ -17,7 +17,7 @@ import {
   libraryShape,
   LOADING_STATUS,
   ROUTES,
-  truncateErrorMessage,
+  truncateMessage,
   XBLOCK_VIEW_SYSTEM,
 } from '../common';
 import {
@@ -228,7 +228,7 @@ class LibraryBlockPage extends React.Component {
                 onClose={this.handleDismissAlert}
                 dismissible
               >
-                {truncateErrorMessage(errorMessage)}
+                {truncateMessage(errorMessage)}
               </Alert>
               )}
               <div className="card">

--- a/src/library-authoring/library-access/LibraryAccessPage.jsx
+++ b/src/library-authoring/library-access/LibraryAccessPage.jsx
@@ -17,7 +17,7 @@ import { LoadingPage } from '../../generic';
 import { fetchLibraryDetail } from '../author-library/data';
 import LibraryAccessFormContainer from './LibraryAccessForm';
 import {
-  LIBRARY_ACCESS, libraryShape, LOADING_STATUS, ROUTES, truncateErrorMessage,
+  LIBRARY_ACCESS, libraryShape, LOADING_STATUS, ROUTES, truncateMessage,
 } from '../common/data';
 import {
   addUser,
@@ -72,7 +72,7 @@ const LibraryAccessPage = ({
               onClose={() => handleDismissAlert()}
               dismissible
             >
-              {truncateErrorMessage(errorMessage)}
+              {truncateMessage(errorMessage)}
             </Alert>
           )}
           {showAdd


### PR DESCRIPTION
This PR adds a feature to copy a block's LTI launch URL to easily integrate with LTI consumers. The copy button reaches out to Studio to the URL instead of composing it on the front-end to give flexibility in future refactors if necessary.

**Dependencies**: 

* https://github.com/edx/edx-platform/pull/27712
* https://github.com/edx/edx-platform/pull/27411

**Screenshots**: 

https://user-images.githubusercontent.com/19173947/119609778-6e991f80-bdf8-11eb-84c3-732684018540.mov

**Sandbox URL**: https://library-authoring.pr27712.sandbox.opencraft.hosting/

**Merge deadline**: None

**Testing instructions**:

* Login to studio
* Switch to the libraries tab
* Create a new library
* Create a new block in the library
* Click on Copy LTI Url button
* Validate the URL is copied
* Check the success message appeared

**Author notes and concerns**:

N/A

**Reviewers**
- [ ] @jvdm
- [ ] TBD